### PR TITLE
Only check coverage on src/

### DIFF
--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   all: true,
-  exclude: ['{dist,coverage,media,test-d,test-tap}/**', '*.config.js'],
+  exclude: ['{dist,coverage,test}/**', '*.config.js'],
   reporter: ['html', 'lcov', 'text'],
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "babel": true,
     "require": [
       "./test/_register.js"
+    ],
+    "files": [
+      "test/**/*.test.js"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Configures `nyc` such that it knows that only our source files are in `src/`

Configures `ava` such that only our test files match `test/**/*.test.js`