### PR TITLE
rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/openskill)](https://www.npmjs.com/package/openskill)
 ![Tests](https://github.com/philihp/openskill.js/workflows/tests/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/philihp/openskill.js/badge.svg?branch=master&force=reload)](https://coveralls.io/github/philihp/openskill.js?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/philihp/openskill.js/badge.svg?branch=main&force=reload)](https://coveralls.io/github/philihp/openskill.js?branch=main)
 ![Downloads](https://img.shields.io/npm/dt/fast-shuffle)
 ![License](https://img.shields.io/npm/l/openskill)
 


### PR DESCRIPTION
Github is now doing this by default for new repos. That's enough of a signal for me to move toward what will be normal in the future.