### PR TITLE
bug: allow mu/sigma to initialize zero

### DIFF
--- a/src/__tests__/rating.test.js
+++ b/src/__tests__/rating.test.js
@@ -24,4 +24,16 @@ describe('rating', () => {
     const { sigma } = rating({ sigma: 6.283185 })
     expect(sigma).toBe(6.283185)
   })
+
+  it('can initialize a mu of zero', () => {
+    expect.assertions(1)
+    const { mu } = rating({ mu: 0 })
+    expect(mu).toBe(0)
+  })
+
+  it('can initialize a sigma of zero', () => {
+    expect.assertions(1)
+    const { sigma } = rating({ sigma: 0 })
+    expect(sigma).toBe(0)
+  })
 })

--- a/src/rating.js
+++ b/src/rating.js
@@ -2,8 +2,8 @@ const DEFAULT_MU = 25.0
 const DEFAULT_SIGMA = DEFAULT_MU / 3.0
 
 const rating = (initial) => ({
-  mu: initial?.mu || DEFAULT_MU,
-  sigma: initial?.sigma || DEFAULT_SIGMA,
+  mu: initial?.mu ?? DEFAULT_MU,
+  sigma: initial?.sigma ?? DEFAULT_SIGMA,
 })
 
 export default rating


### PR DESCRIPTION
resolves a bug if you try to init a rating at zero, which is certainly reasonable if you want your average `mu` to be centered on zero.