### PR TITLE
Support for tied rankings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ If `a1` and `a2` are on a team, and wins against a team of `b1` and `b2`, send t
 > const [[x1, x2], [y1, y2]] = rate([[a1, a2], [b1, b2]])
 [
   [
-    { mu: 28.669648436582808, sigma: 8.071520788025197 },
-    { mu: 33.83086971107981, sigma: 5.062772998705765 }
+    { mu: 28.67..., sigma: 8.07...},
+    { mu: 33.83..., sigma: 5.06...}
   ],
   [
-    { mu: 43.071274808241974, sigma: 2.4166900452721256 },
-    { mu: 23.149503312339064, sigma: 6.1378606973362135 }
+    { mu: 43.07..., sigma: 2.42...},
+    { mu: 23.15..., sigma: 6.14...}
   ]
 ]
 ```
@@ -76,8 +76,8 @@ When displaying a rating, or sorting a list of ratings, you can use `ordinal`
 
 ```js
 > const { ordinal } = require('openskill')
-> ordinal({ mu: 43.071274808241974, sigma: 2.4166900452721256})
-35.821204672425594
+> ordinal({ mu: 43.07, sigma: 2.42})
+35.81
 ```
 
 By default, this returns `mu - 3*sigma`, showing a rating for which there's a 99.5% likelihood the player's true rating is higher, so with early games, a player's ordinal rating will usually go up and could go up even if that player loses.
@@ -88,16 +88,37 @@ If your teams are listed in one order but your ranking is in a different order, 
 
 ```js
 > const a1 = b1 = c1 = d1 = rating()
-> const [a2, b2, c2, d2] = rate([a1, b1, c1, d1], rank: [4, 1, 3, 2])
+> const [a2, b2, c2, d2] = rate([[a1], [b1], [c1], [d1]], {
+    { rank: [4, 1, 3, 2]
+  })
 [
-  [{ mu: 20.96..., sigma: 8.08... }],
-  [{ mu: 27.79..., sigma: 8.26... }],
+  [{ mu: 20.96..., sigma: 8.08... }], // came in last, so 25.00 -> 20.96
+  [{ mu: 27.79..., sigma: 8.26... }], // came in first, so 25.00 -> 27.69
   [{ mu: 24.68..., sigma: 8.08... }],
   [{ mu: 26.55..., sigma: 8.17... }],
 ]
 ```
 
+It's assumed that the lower ranks are better (wins), while higher ranks are worse (losses). You can provide a `score` instead, where lower is worse and higher is better. These can just be raw scores from the game, if you want.
+
+Ties should have either equivalent rank or score.
+
+```js
+> const a1 = rating()
+> const b1 = rating()
+> const c1 = rating()
+> const d1 = rating()
+> const [a2, b2, c2, d2] = rate([a1], [b1], [c1], [d1]], {
+    rank: [2, 4, 2, 1]
+  })
+[
+  { mu: 26.62...,  sigma: 8.31... }, // second
+  { mu: 49.07...,  sigma: 8.26... }, // last
+  { mu: 73.33...,  sigma: 8.20... }, // second
+  { mu: 100.96..., sigma: 8.26... }, // first
+]
+```
+
 ## TODO
 
-- Support tied rankings, e.g. `Openskill.rank([[p1],[p2],[p3],[p4]], ranks: [1, 2, 2, 4])`
 - Configurable alternate `gamma` to avoid ill-conditioning problems from large numbers of teams, as discussed in the paper.

--- a/src/__tests__/rate.test.js
+++ b/src/__tests__/rate.test.js
@@ -1,4 +1,24 @@
+import { transition } from '../rate'
 import { rate, rating } from '..'
+
+describe('rate#transition', () => {
+  const a = 'a'
+  const b = 'b'
+  const c = 'c'
+  const d = 'd'
+  const natural = [a, c, d, b]
+  const ordered = [a, b, c, d]
+  it('inverts a normal array', () => {
+    expect.assertions(1)
+    const result = transition(natural, ordered)
+    expect(result).toStrictEqual([0, 3, 1, 2])
+  })
+  it('reverses the array', () => {
+    expect.assertions(1)
+    const result = transition(ordered, natural)
+    expect(result).toStrictEqual([0, 2, 3, 1])
+  })
+})
 
 describe('rate', () => {
   const a1 = rating({ mu: 29.182, sigma: 4.782 })
@@ -7,12 +27,10 @@ describe('rate', () => {
   const d1 = rating()
   const e1 = rating()
   const f1 = rating()
-
   const w1 = rating({ mu: 25 })
   const x1 = rating({ mu: 50 })
   const y1 = rating({ mu: 75 })
   const z1 = rating({ mu: 100 })
-
   it('rate accepts and runs a placket-luce model by default', () => {
     expect.assertions(1)
     const [[a2], [b2], [c2], [d2]] = rate([[a1], [b1], [c1], [d1]])
@@ -56,6 +74,32 @@ describe('rate', () => {
       { mu: 20.979038689398703, sigma: 8.129445198549202 },
       { mu: 27.341134074194173, sigma: 8.231039243636156 },
       { mu: 26.679827236407125, sigma: 8.148750467726549 },
+    ])
+  })
+
+  it('fixes orders of ties', () => {
+    expect.assertions(1)
+    const [[w2], [x2], [y2], [z2]] = rate([[w1], [x1], [y1], [z1]], {
+      rank: [2, 4, 2, 1],
+    })
+    expect([w2, x2, y2, z2]).toStrictEqual([
+      { mu: 32.212629604515094, sigma: 8.31025813361969 },
+      { mu: 49.0783656590492, sigma: 8.25617415661398 },
+      { mu: 78.92801836297117, sigma: 8.204569273806177 },
+      { mu: 100.96132626096349, sigma: 8.261690241098727 },
+    ])
+  })
+
+  it('accepts a score instead of rank', () => {
+    expect.assertions(1)
+    const [[w2], [x2], [y2], [z2]] = rate([[w1], [x1], [y1], [z1]], {
+      score: [50, 40, 50, 100],
+    })
+    expect([w2, x2, y2, z2]).toStrictEqual([
+      { mu: 32.212629604515094, sigma: 8.31025813361969 },
+      { mu: 49.0783656590492, sigma: 8.25617415661398 },
+      { mu: 78.92801836297117, sigma: 8.204569273806177 },
+      { mu: 100.96132626096349, sigma: 8.261690241098727 },
     ])
   })
 })

--- a/src/__tests__/rate.test.js
+++ b/src/__tests__/rate.test.js
@@ -1,24 +1,4 @@
-import { transition } from '../rate'
 import { rate, rating } from '..'
-
-describe('rate#transition', () => {
-  const a = 'a'
-  const b = 'b'
-  const c = 'c'
-  const d = 'd'
-  const natural = [a, c, d, b]
-  const ordered = [a, b, c, d]
-  it('inverts a normal array', () => {
-    expect.assertions(1)
-    const result = transition(natural, ordered)
-    expect(result).toStrictEqual([0, 3, 1, 2])
-  })
-  it('reverses the array', () => {
-    expect.assertions(1)
-    const result = transition(ordered, natural)
-    expect(result).toStrictEqual([0, 2, 3, 1])
-  })
-})
 
 describe('rate', () => {
   const a1 = rating({ mu: 29.182, sigma: 4.782 })
@@ -31,6 +11,7 @@ describe('rate', () => {
   const x1 = rating({ mu: 50 })
   const y1 = rating({ mu: 75 })
   const z1 = rating({ mu: 100 })
+
   it('rate accepts and runs a placket-luce model by default', () => {
     expect.assertions(1)
     const [[a2], [b2], [c2], [d2]] = rate([[a1], [b1], [c1], [d1]])
@@ -83,23 +64,36 @@ describe('rate', () => {
       rank: [2, 4, 2, 1],
     })
     expect([w2, x2, y2, z2]).toStrictEqual([
-      { mu: 32.212629604515094, sigma: 8.31025813361969 },
+      { mu: 26.62245966076562, sigma: 8.31025813361969 },
       { mu: 49.0783656590492, sigma: 8.25617415661398 },
-      { mu: 78.92801836297117, sigma: 8.204569273806177 },
+      { mu: 73.3378484192217, sigma: 8.204569273806177 },
       { mu: 100.96132626096349, sigma: 8.261690241098727 },
+    ])
+  })
+
+  it('runs a model when tied for first', () => {
+    expect.assertions(1)
+    const [[w2], [x2], [y2], [z2]] = rate([[e1], [e1], [e1], [e1]], {
+      model: 'thurstonMostellerFull',
+      score: [100, 84, 100, 72],
+    })
+    expect([w2, x2, y2, z2]).toStrictEqual([
+      { mu: 33.41049241772118, sigma: 6.861184222487201 },
+      { mu: 20.79475379113941, sigma: 5.99095578185474 },
+      { mu: 33.41049241772118, sigma: 6.861184222487201 },
+      { mu: 12.38426137341823, sigma: 5.99095578185474 },
     ])
   })
 
   it('accepts a score instead of rank', () => {
     expect.assertions(1)
-    const [[w2], [x2], [y2], [z2]] = rate([[w1], [x1], [y1], [z1]], {
-      score: [50, 40, 50, 100],
+    const [[x2], [y2], [z2]] = rate([[e1], [e1], [e1]], {
+      score: [1, 1, 1],
     })
-    expect([w2, x2, y2, z2]).toStrictEqual([
-      { mu: 32.212629604515094, sigma: 8.31025813361969 },
-      { mu: 49.0783656590492, sigma: 8.25617415661398 },
-      { mu: 78.92801836297117, sigma: 8.204569273806177 },
-      { mu: 100.96132626096349, sigma: 8.261690241098727 },
+    expect([x2, y2, z2]).toStrictEqual([
+      { mu: 25, sigma: 8.204837030780652 },
+      { mu: 25, sigma: 8.204837030780652 },
+      { mu: 25, sigma: 8.204837030780652 },
     ])
   })
 })

--- a/src/__tests__/rate.test.js
+++ b/src/__tests__/rate.test.js
@@ -8,6 +8,11 @@ describe('rate', () => {
   const e1 = rating()
   const f1 = rating()
 
+  const w1 = rating({ mu: 25 })
+  const x1 = rating({ mu: 50 })
+  const y1 = rating({ mu: 75 })
+  const z1 = rating({ mu: 100 })
+
   it('rate accepts and runs a placket-luce model by default', () => {
     expect.assertions(1)
     const [[a2], [b2], [c2], [d2]] = rate([[a1], [b1], [c1], [d1]])
@@ -21,14 +26,14 @@ describe('rate', () => {
 
   it('accepts a rate ordering', () => {
     expect.assertions(1)
-    const [[a2], [b2], [c2], [d2]] = rate([[d1], [b1], [c1], [a1]], {
-      rank: [4, 2, 3, 1],
+    const [[w2], [x2], [y2], [z2]] = rate([[w1], [x1], [y1], [z1]], {
+      rank: [1, 3, 4, 2],
     })
-    expect([[a2], [b2], [c2], [d2]]).toStrictEqual([
-      [{ mu: 30.209971908310553, sigma: 4.764898977359521 }],
-      [{ mu: 27.64460833689499, sigma: 4.882789305097372 }],
-      [{ mu: 17.403586731283518, sigma: 6.100723440599442 }],
-      [{ mu: 19.214790707434826, sigma: 7.8542613981643985 }],
+    expect([w2, x2, y2, z2]).toStrictEqual([
+      { mu: 28.67737565442646, sigma: 8.328456968941984 },
+      { mu: 52.57392768912515, sigma: 8.235421539444559 },
+      { mu: 70.58997703962795, sigma: 8.153023344882628 },
+      { mu: 98.15871961682043, sigma: 8.191288071064596 },
     ])
   })
 
@@ -45,12 +50,12 @@ describe('rate', () => {
       }
     )
     expect([a2, b2, c2, d2, e2, f2]).toStrictEqual([
+      { mu: 27.857928218465247, sigma: 4.743791738484319 },
       { mu: 27.99071775460834, sigma: 4.901007097140011 },
       { mu: 17.60695098907354, sigma: 6.140737155130899 },
-      { mu: 27.857928218465247, sigma: 4.743791738484319 },
+      { mu: 20.979038689398703, sigma: 8.129445198549202 },
       { mu: 27.341134074194173, sigma: 8.231039243636156 },
       { mu: 26.679827236407125, sigma: 8.148750467726549 },
-      { mu: 20.979038689398703, sigma: 8.129445198549202 },
     ])
   })
 })

--- a/src/__tests__/rate/transition.test.js
+++ b/src/__tests__/rate/transition.test.js
@@ -1,0 +1,20 @@
+import { transition } from '../../rate'
+
+describe('rate#transition', () => {
+  const a = 'a'
+  const b = 'b'
+  const c = 'c'
+  const d = 'd'
+  const natural = [a, c, d, b]
+  const ordered = [a, b, c, d]
+  it('inverts a normal array', () => {
+    expect.assertions(1)
+    const result = transition(natural, ordered)
+    expect(result).toStrictEqual([0, 3, 1, 2])
+  })
+  it('reverses the array', () => {
+    expect.assertions(1)
+    const result = transition(ordered, natural)
+    expect(result).toStrictEqual([0, 2, 3, 1])
+  })
+})

--- a/src/__tests__/util/rankings.test.js
+++ b/src/__tests__/util/rankings.test.js
@@ -1,0 +1,40 @@
+import { rankings } from '../../util'
+
+const a = 'a'
+const b = 'b'
+const c = 'c'
+const d = 'd'
+const e = 'e'
+
+describe('util#rankings', () => {
+  it('ranks given undefined', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], undefined)).toStrictEqual([1, 2, 3, 4])
+  })
+  it('ranks given incremental', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], [1, 2, 3, 4])).toStrictEqual([1, 2, 3, 4])
+  })
+  it('ranks with ties in start', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], [1, 1, 3, 4])).toStrictEqual([1, 1, 3, 4])
+  })
+  it('ranks with ties at end', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], [1, 2, 3, 3])).toStrictEqual([1, 2, 3, 3])
+  })
+  it('ranks with ties in the middle', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], [1, 2, 2, 4])).toStrictEqual([1, 2, 2, 4])
+  })
+  it('ranks sparse scores', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d, e], [14, 32, 47, 47, 48])).toStrictEqual([
+      1,
+      2,
+      3,
+      3,
+      5,
+    ])
+  })
+})

--- a/src/__tests__/util/reorder.test.js
+++ b/src/__tests__/util/reorder.test.js
@@ -14,37 +14,53 @@ describe('util#reorder', () => {
 
   it('accepts 1 item', () => {
     expect.assertions(1)
-    expect(reorder([1])([a])).toStrictEqual([a])
+    expect(reorder([1])([a])).toStrictEqual([[a], [1]])
   })
 
   it('accepts 2 items', () => {
     expect.assertions(1)
-    expect(reorder([2, 1])([a, b])).toStrictEqual([b, a])
+    expect(reorder([2, 1])([a, b])).toStrictEqual([
+      [b, a],
+      [1, 2],
+    ])
   })
 
   it('accepts 3 items', () => {
     expect.assertions(1)
-    expect(reorder([2, 3, 1])([a, b, c])).toStrictEqual([c, a, b])
+    expect(reorder([2, 3, 1])([a, b, c])).toStrictEqual([
+      [c, a, b],
+      [1, 2, 3],
+    ])
   })
 
   it('accepts 4 items', () => {
     expect.assertions(1)
-    expect(reorder([2, 4, 3, 1])(source)).toStrictEqual([d, a, c, b])
+    expect(reorder([2, 4, 3, 1])(source)).toStrictEqual([
+      [d, a, c, b],
+      [1, 2, 3, 4],
+    ])
   })
 
   it('works with numbers of float, sparse rankings', () => {
     expect.assertions(1)
-    expect(reorder([2.45, 0, 7.12])([a, b, c])).toStrictEqual([b, a, c])
+    expect(reorder([2.45, 0, 7.12])([a, b, c])).toStrictEqual([
+      [b, a, c],
+      [0, 2.45, 7.12],
+    ])
   })
 
   it('does not reorder if rank is missing', () => {
-    expect.assertions(1)
-    expect(reorder(undefined)(source)).toBe(source)
+    expect.assertions(2)
+    expect(reorder(undefined)(source)[0]).toBe(source)
+    expect(reorder(undefined)(source)[1]).toBeUndefined()
   })
 
   it('can be curried', () => {
     expect.assertions(1)
     const curriedReorder = reorder([4, 3, 2, 1])
-    expect(curriedReorder(source)).toStrictEqual([d, c, b, a])
+    expect(curriedReorder(source)).toStrictEqual([
+      [d, c, b, a],
+      [1, 2, 3, 4],
+    ])
   })
 })

--- a/src/__tests__/util/util-a.test.js
+++ b/src/__tests__/util/util-a.test.js
@@ -11,8 +11,8 @@ describe('util#utilA', () => {
     const teamRatings = teamRating([team1, team2])
     const a = utilA(teamRatings)
     expect(a).toStrictEqual({
+      0: 1,
       1: 1,
-      2: 1,
     })
   })
 })

--- a/src/__tests__/util/util-sum-q.test.js
+++ b/src/__tests__/util/util-sum-q.test.js
@@ -12,8 +12,8 @@ describe('util#utilSumQ', () => {
     const c = utilC(teamRatings)
     const sumQ = utilSumQ(teamRatings, c)
     expect(sumQ).toStrictEqual({
-      1: 29.67892702634643,
-      2: 24.70819334370875,
+      0: 29.67892702634643,
+      1: 24.70819334370875,
     })
   })
 })

--- a/src/models/bradley-terry-full.js
+++ b/src/models/bradley-terry-full.js
@@ -3,8 +3,8 @@ import { BETASQ, EPSILON } from '../constants'
 
 const TWOBETASQ = 2 * BETASQ
 
-export default (game) => {
-  const teamRatings = teamRating(game)
+export default (game, options = {}) => {
+  const teamRatings = teamRating(game, options)
 
   return teamRatings.map(([iMu, iSigmaSq, iTeam, iRank]) => {
     const [iOmega, iDelta] = teamRatings

--- a/src/models/bradley-terry-part.js
+++ b/src/models/bradley-terry-part.js
@@ -4,8 +4,8 @@ import { BETASQ, EPSILON } from '../constants'
 
 const TWOBETASQ = 2 * BETASQ
 
-export default (game) => {
-  const teamRatings = teamRating(game)
+export default (game, options = {}) => {
+  const teamRatings = teamRating(game, options)
   const adjacentTeams = ladderPairs(teamRatings)
   return zip(teamRatings, adjacentTeams).map(([iTeamRating, iAdjacent]) => {
     const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating

--- a/src/models/plackett-luce.js
+++ b/src/models/plackett-luce.js
@@ -8,17 +8,17 @@ export default (game, options = {}) => {
   const sumQ = utilSumQ(teamRatings, c)
   const a = utilA(teamRatings)
 
-  return teamRatings.map(([iMu, iSigmaSq, iTeam, iRank]) => {
+  return teamRatings.map(([iMu, iSigmaSq, iTeam, iRank], i) => {
     const iMuOverCe = Math.exp(iMu / c)
     const [omegaSet, deltaSet] = transpose(
       teamRatings
         .filter(([_qMu, _qSigmaSq, _qTeam, qRank]) => qRank <= iRank)
-        .map(([_qMu, _qSigmaSq, _qTeam, qRank]) => {
-          const quotient = iMuOverCe / sumQ[qRank]
-          const mu =
-            qRank === iRank ? 1 - quotient / a[qRank] : -quotient / a[qRank]
-          const sigma = (quotient * (1 - quotient)) / a[qRank]
-          return [mu, sigma]
+        .map(([_], q) => {
+          const quotient = iMuOverCe / sumQ[q]
+          return [
+            (i === q ? 1 - quotient : -quotient) / a[q],
+            (quotient * (1 - quotient)) / a[q],
+          ]
         })
     )
     const gamma = Math.sqrt(iSigmaSq) / c

--- a/src/models/plackett-luce.js
+++ b/src/models/plackett-luce.js
@@ -2,8 +2,8 @@ import { transpose } from 'ramda'
 import { teamRating, utilSumQ, utilC, utilA, sum } from '../util'
 import { EPSILON } from '../constants'
 
-export default (game) => {
-  const teamRatings = teamRating(game)
+export default (game, options = {}) => {
+  const teamRatings = teamRating(game, options)
   const c = utilC(teamRatings)
   const sumQ = utilSumQ(teamRatings, c)
   const a = utilA(teamRatings)

--- a/src/models/thurston-mosteller-full.js
+++ b/src/models/thurston-mosteller-full.js
@@ -4,8 +4,8 @@ import { BETASQ, EPSILON } from '../constants'
 
 const TWOBETASQ = 2 * BETASQ
 
-export default (game) => {
-  const teamRatings = teamRating(game)
+export default (game, options = {}) => {
+  const teamRatings = teamRating(game, options)
 
   return teamRatings.map(([iMu, iSigmaSq, iTeam, iRank]) => {
     const [iOmega, iDelta] = teamRatings

--- a/src/models/thurston-mosteller-part.js
+++ b/src/models/thurston-mosteller-part.js
@@ -5,8 +5,8 @@ import { BETASQ, EPSILON } from '../constants'
 
 const TWOBETASQ = 2 * BETASQ
 
-export default (game) => {
-  const teamRatings = teamRating(game)
+export default (game, options = {}) => {
+  const teamRatings = teamRating(game, options)
   const adjacentTeams = ladderPairs(teamRatings)
 
   return zip(teamRatings, adjacentTeams).map(([iTeamRating, iAdjacent]) => {

--- a/src/rate.js
+++ b/src/rate.js
@@ -1,13 +1,11 @@
 import models from './models'
 import { reorder } from './util'
 
-// finds the indexes used to unshuffle, O(n^2)
-// [ 1, 3, 4, 2 ] --> [ 1, 4, 2, 3 ]
-const reversedOrder = (rank) => {
-  return rank.map((n, i) => {
-    const j = rank.indexOf(i + 1) + 1
-    return j
+export const transition = (postTeams, preTeams) => {
+  const out = preTeams.map((t, i) => {
+    return postTeams.indexOf(t)
   })
+  return out
 }
 
 const rate = (teams, options = {}) => {
@@ -18,7 +16,7 @@ const rate = (teams, options = {}) => {
     return model(teams, options)
   }
 
-  // if rank provided, use it, otherwise invert scores and use that
+  // if rank provided, use it, otherwise transition scores and use that
   const rank = options.rank ?? options.score.map((points) => -points)
   const [orderedTeams, orderedRanks] = reorder(rank)(teams)
 
@@ -27,7 +25,7 @@ const rate = (teams, options = {}) => {
     rank: orderedRanks,
   })
 
-  const derank = reversedOrder(rank)
+  const derank = transition(teams, orderedTeams)
   const [reorderedTeams] = reorder(derank)(newRatings)
   return reorderedTeams
 }

--- a/src/rate.js
+++ b/src/rate.js
@@ -2,6 +2,6 @@ import models from './models'
 import { reorder } from './util'
 
 const rate = (teams, options = {}) =>
-  models[options.model || 'plackettLuce'](reorder(options.rank)(teams))
+  models[options.model || 'plackettLuce'](reorder(options.rank)(teams, options))
 
 export default rate

--- a/src/rate.js
+++ b/src/rate.js
@@ -1,19 +1,35 @@
 import models from './models'
 import { reorder } from './util'
 
+// finds the indexes used to unshuffle, O(n^2)
+// [ 1, 3, 4, 2 ] --> [ 1, 4, 2, 3 ]
+const reversedOrder = (rank) => {
+  return rank.map((n, i) => {
+    const j = rank.indexOf(i + 1) + 1
+    return j
+  })
+}
+
 const rate = (teams, options = {}) => {
   const model = models[options.model || 'plackettLuce']
 
-  if (options.rank === undefined) {
+  // if no rank or score provided, use natural ordering
+  if (options.rank === undefined && options.score === undefined) {
     return model(teams, options)
   }
 
-  const [orderedTeams, orderedRanks] = reorder(options.rank)(teams)
+  // if rank provided, use it, otherwise invert scores and use that
+  const rank = options.rank ?? options.score.map((points) => -points)
+  const [orderedTeams, orderedRanks] = reorder(rank)(teams)
 
-  return model(orderedTeams, {
+  const newRatings = model(orderedTeams, {
     ...options,
     rank: orderedRanks,
   })
+
+  const derank = reversedOrder(rank)
+  const [reorderedTeams] = reorder(derank)(newRatings)
+  return reorderedTeams
 }
 
 export default rate

--- a/src/rate.js
+++ b/src/rate.js
@@ -1,7 +1,19 @@
 import models from './models'
 import { reorder } from './util'
 
-const rate = (teams, options = {}) =>
-  models[options.model || 'plackettLuce'](reorder(options.rank)(teams, options))
+const rate = (teams, options = {}) => {
+  const model = models[options.model || 'plackettLuce']
+
+  if (options.rank === undefined) {
+    return model(teams, options)
+  }
+
+  const [orderedTeams, orderedRanks] = reorder(options.rank)(teams)
+
+  return model(orderedTeams, {
+    ...options,
+    rank: orderedRanks,
+  })
+}
 
 export default rate

--- a/src/rate.js
+++ b/src/rate.js
@@ -1,12 +1,8 @@
 import models from './models'
 import { reorder } from './util'
 
-export const transition = (postTeams, preTeams) => {
-  const out = preTeams.map((t, i) => {
-    return postTeams.indexOf(t)
-  })
-  return out
-}
+export const transition = (postTeams, preTeams) =>
+  preTeams.map((t) => postTeams.indexOf(t))
 
 const rate = (teams, options = {}) => {
   const model = models[options.model || 'plackettLuce']

--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,7 @@ export const sum = (a, b) => a + b
 const intoRankHash = (accum, value, index) => {
   return {
     ...accum,
-    [index + 1]: value,
+    [index]: value,
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-import { zip, sort, map, pipe } from 'ramda'
+import { zip, sort, pipe, transpose, reverse } from 'ramda'
 import { BETASQ } from './constants'
 
 export const sum = (a, b) => a + b
@@ -90,10 +90,11 @@ export const utilA = (teamRatings) =>
     .reduce(intoRankHash, {})
 
 export const reorder = (rank) => (teams) => {
-  if (rank === undefined) return teams
+  if (rank === undefined) return [teams]
   return pipe(
     zip,
     sort(([a], [b]) => a - b),
-    map(([_, team]) => team)
-  )(rank, teams)
+    transpose,
+    reverse
+  )(rank, teams) // -> [orderedTeams, orderedRanks]
 }

--- a/src/util.js
+++ b/src/util.js
@@ -21,13 +21,34 @@ export const score = (q, i) => {
   return 0.5
 }
 
-export const teamRating = (game) =>
-  game.map((team, i) => [
+export const rankings = (teams, rank = []) => {
+  const teamScores = teams.map((_, i) => rank[i] || i)
+  const outRank = new Array(teams.length)
+
+  let s = 0
+  for (let j = 0; j < teamScores.length; j += 1) {
+    if (j > 0 && teamScores[j - 1] < teamScores[j]) {
+      s = j
+    }
+    outRank[j] = s + 1
+  }
+  return outRank
+}
+
+// this is basically shared code, precomputed for every model
+export const teamRating = (game, options = {}) => {
+  const rank = rankings(game, options.rank)
+  return game.map((team, i) => [
+    // mu[i]
     team.map(({ mu }) => mu).reduce(sum, 0),
+    // sigma^2[i]
     team.map(({ sigma }) => sigma * sigma).reduce(sum, 0),
+    // (original team data)
     team,
-    i + 1,
+    // rank[i]
+    rank[i],
   ])
+}
 
 export const ladderPairs = (ranks) => {
   const size = ranks.length


### PR DESCRIPTION
* Fixed some bugs with reordering, so that it also reordered the provided rank. This is important, because to properly build the rank for ties so they're reindexed at 1, they both have to be in order.
* Sends in a reindexed rank, rather than just the index of the teams which was there as a placeholder.
* Opportunity here to rewrite some stuff in a more functional, less procedural way.
* TODO: Tied rankings currently works for all models except plackettLuce... looking into this