### PR TITLE
Customizable gamma function

### DIFF
--- a/src/models/__tests__/bradley-terry-full.test.js
+++ b/src/models/__tests__/bradley-terry-full.test.js
@@ -1,8 +1,6 @@
 import { rating } from '../..'
 import rate from '../bradley-terry-full'
 
-const gamma = (_ciq, k, _mu, _sigmaSq, _team, _qRank) => 1 / k
-
 describe('bradleyTerryFull', () => {
   const r = rating()
   const team1 = [r]
@@ -70,7 +68,7 @@ describe('bradleyTerryFull', () => {
 
   it('can use a custom gamma with k=2', () => {
     expect.assertions(1)
-    expect(rate([team1, team1], { gamma })).toStrictEqual([
+    expect(rate([team1, team1], { gamma: (_, k) => 1 / k })).toStrictEqual([
       [{ mu: 27.63523138347365, sigma: 8.122328620674137 }],
       [{ mu: 22.36476861652635, sigma: 8.122328620674137 }],
     ])
@@ -78,7 +76,9 @@ describe('bradleyTerryFull', () => {
 
   it('can use a custom gamma with k=5', () => {
     expect.assertions(1)
-    expect(rate([team1, team1, team1, team1, team1], { gamma })).toStrictEqual([
+    expect(
+      rate([team1, team1, team1, team1, team1], { gamma: (_, k) => 1 / k })
+    ).toStrictEqual([
       [{ mu: 35.5409255338946, sigma: 7.993052538854532 }],
       [{ mu: 30.2704627669473, sigma: 7.993052538854532 }],
       [{ mu: 25, sigma: 7.993052538854532 }],

--- a/src/models/__tests__/bradley-terry-full.test.js
+++ b/src/models/__tests__/bradley-terry-full.test.js
@@ -1,6 +1,8 @@
 import { rating } from '../..'
 import rate from '../bradley-terry-full'
 
+const gamma = (_ciq, k, _mu, _sigmaSq, _team, _qRank) => 1 / k
+
 describe('bradleyTerryFull', () => {
   const r = rating()
   const team1 = [r]
@@ -63,6 +65,25 @@ describe('bradleyTerryFull', () => {
         { mu: 20.518164784802714, sigma: 8.127515465304823 },
         { mu: 20.518164784802714, sigma: 8.127515465304823 },
       ],
+    ])
+  })
+
+  it('can use a custom gamma with k=2', () => {
+    expect.assertions(1)
+    expect(rate([team1, team1], { gamma })).toStrictEqual([
+      [{ mu: 27.63523138347365, sigma: 8.122328620674137 }],
+      [{ mu: 22.36476861652635, sigma: 8.122328620674137 }],
+    ])
+  })
+
+  it('can use a custom gamma with k=5', () => {
+    expect.assertions(1)
+    expect(rate([team1, team1, team1, team1, team1], { gamma })).toStrictEqual([
+      [{ mu: 35.5409255338946, sigma: 7.993052538854532 }],
+      [{ mu: 30.2704627669473, sigma: 7.993052538854532 }],
+      [{ mu: 25, sigma: 7.993052538854532 }],
+      [{ mu: 19.729537233052703, sigma: 7.993052538854532 }],
+      [{ mu: 14.4590744661054, sigma: 7.993052538854532 }],
     ])
   })
 })

--- a/src/models/__tests__/bradley-terry-part.test.js
+++ b/src/models/__tests__/bradley-terry-part.test.js
@@ -1,8 +1,6 @@
 import { rating } from '../..'
 import rate from '../bradley-terry-part'
 
-const gamma = (_ciq, k, _mu, _sigmaSq, _team, _qRank) => 1 / k
-
 describe('bradleyTerryPart', () => {
   const r = rating()
   const team1 = [r]
@@ -70,7 +68,7 @@ describe('bradleyTerryPart', () => {
 
   it('can use a custom gamma with k=2', () => {
     expect.assertions(1)
-    expect(rate([team1, team1], { gamma })).toStrictEqual([
+    expect(rate([team1, team1], { gamma: (_, k) => 1 / k })).toStrictEqual([
       [{ mu: 27.63523138347365, sigma: 8.122328620674137 }],
       [{ mu: 22.36476861652635, sigma: 8.122328620674137 }],
     ])
@@ -78,7 +76,9 @@ describe('bradleyTerryPart', () => {
 
   it('can use a custom gamma with k=5', () => {
     expect.assertions(1)
-    expect(rate([team1, team1, team1, team1, team1], { gamma })).toStrictEqual([
+    expect(
+      rate([team1, team1, team1, team1, team1], { gamma: (_, k) => 1 / k })
+    ).toStrictEqual([
       [{ mu: 27.63523138347365, sigma: 8.249579113843055 }],
       [{ mu: 25, sigma: 8.16496580927726 }],
       [{ mu: 25, sigma: 8.16496580927726 }],

--- a/src/models/__tests__/bradley-terry-part.test.js
+++ b/src/models/__tests__/bradley-terry-part.test.js
@@ -1,6 +1,8 @@
 import { rating } from '../..'
 import rate from '../bradley-terry-part'
 
+const gamma = (_ciq, k, _mu, _sigmaSq, _team, _qRank) => 1 / k
+
 describe('bradleyTerryPart', () => {
   const r = rating()
   const team1 = [r]
@@ -63,6 +65,25 @@ describe('bradleyTerryPart', () => {
         { mu: 21.291677238090045, sigma: 8.206896387427937 },
         { mu: 21.291677238090045, sigma: 8.206896387427937 },
       ],
+    ])
+  })
+
+  it('can use a custom gamma with k=2', () => {
+    expect.assertions(1)
+    expect(rate([team1, team1], { gamma })).toStrictEqual([
+      [{ mu: 27.63523138347365, sigma: 8.122328620674137 }],
+      [{ mu: 22.36476861652635, sigma: 8.122328620674137 }],
+    ])
+  })
+
+  it('can use a custom gamma with k=5', () => {
+    expect.assertions(1)
+    expect(rate([team1, team1, team1, team1, team1], { gamma })).toStrictEqual([
+      [{ mu: 27.63523138347365, sigma: 8.249579113843055 }],
+      [{ mu: 25, sigma: 8.16496580927726 }],
+      [{ mu: 25, sigma: 8.16496580927726 }],
+      [{ mu: 25, sigma: 8.16496580927726 }],
+      [{ mu: 22.36476861652635, sigma: 8.249579113843055 }],
     ])
   })
 })

--- a/src/models/__tests__/thurston-mosteller-full.test.js
+++ b/src/models/__tests__/thurston-mosteller-full.test.js
@@ -65,4 +65,31 @@ describe('thurstonMostellerFull', () => {
       ],
     ])
   })
+
+  it('can use a custom gamma with k=2', () => {
+    expect.assertions(1)
+    expect(
+      rate([team1, team1], {
+        gamma: (_, k) => 1 / k,
+      })
+    ).toStrictEqual([
+      [{ mu: 29.20524620886059, sigma: 7.784759515283723 }],
+      [{ mu: 20.79475379113941, sigma: 7.784759515283723 }],
+    ])
+  })
+
+  it('can use a custom gamma with k=5', () => {
+    expect.assertions(1)
+    expect(
+      rate([team1, team1, team1, team1, team1], {
+        gamma: (_, k) => 1 / k,
+      })
+    ).toStrictEqual([
+      [{ mu: 41.82098483544236, sigma: 7.436215601407348 }],
+      [{ mu: 33.41049241772118, sigma: 7.436215601407348 }],
+      [{ mu: 25, sigma: 7.436215601407348 }],
+      [{ mu: 16.58950758227882, sigma: 7.436215601407348 }],
+      [{ mu: 8.17901516455764, sigma: 7.436215601407348 }],
+    ])
+  })
 })

--- a/src/models/__tests__/thurston-mosteller-part.test.js
+++ b/src/models/__tests__/thurston-mosteller-part.test.js
@@ -65,4 +65,25 @@ describe('thurstonMostellerPart', () => {
       ],
     ])
   })
+
+  it('can use a custom gamma with k=2', () => {
+    expect.assertions(1)
+    expect(rate([team1, team1], { gamma: (_, k) => 1 / k })).toStrictEqual([
+      [{ mu: 29.20524620886059, sigma: 7.784759515283723 }],
+      [{ mu: 20.79475379113941, sigma: 7.784759515283723 }],
+    ])
+  })
+
+  it('can use a custom gamma with k=5', () => {
+    expect.assertions(1)
+    expect(
+      rate([team1, team1, team1, team1, team1], { gamma: (_, k) => 1 / k })
+    ).toStrictEqual([
+      [{ mu: 29.20524620886059, sigma: 8.118353216692832 }],
+      [{ mu: 25, sigma: 7.897523248305714 }],
+      [{ mu: 25, sigma: 7.897523248305714 }],
+      [{ mu: 25, sigma: 7.897523248305714 }],
+      [{ mu: 20.79475379113941, sigma: 8.118353216692832 }],
+    ])
+  })
 })

--- a/src/models/bradley-terry-full.js
+++ b/src/models/bradley-terry-full.js
@@ -3,10 +3,11 @@ import constants from '../constants'
 
 export default (game, options = {}) => {
   const { TWOBETASQ, EPSILON } = constants(options)
-  const { teamRating } = util(options)
+  const { teamRating, gamma } = util(options)
   const teamRatings = teamRating(game)
 
-  return teamRatings.map(([iMu, iSigmaSq, iTeam, iRank]) => {
+  return teamRatings.map((iTeamRating) => {
+    const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating
     const [iOmega, iDelta] = teamRatings
       .filter(([_qMu, _qSigmaSq, _qTeam, qRank]) => qRank !== iRank)
       .reduce(
@@ -14,11 +15,11 @@ export default (game, options = {}) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const piq = 1 / (1 + Math.exp((qMu - iMu) / ciq))
           const sigSqToCiq = iSigmaSq / ciq
-          const gamma = Math.sqrt(iSigmaSq) / ciq
+          const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
           return [
             omega + sigSqToCiq * (score(qRank, iRank) - piq),
-            delta + ((gamma * sigSqToCiq) / ciq) * piq * (1 - piq),
+            delta + ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq),
           ]
         },
         [0, 0]

--- a/src/models/bradley-terry-part.js
+++ b/src/models/bradley-terry-part.js
@@ -4,7 +4,7 @@ import constants from '../constants'
 
 export default (game, options = {}) => {
   const { TWOBETASQ, EPSILON } = constants(options)
-  const { teamRating } = util(options)
+  const { teamRating, gamma } = util(options)
 
   const teamRatings = teamRating(game)
   const adjacentTeams = ladderPairs(teamRatings)
@@ -17,11 +17,11 @@ export default (game, options = {}) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const piq = 1 / (1 + Math.exp((qMu - iMu) / ciq))
           const sigSqToCiq = iSigmaSq / ciq
-          const gamma = Math.sqrt(iSigmaSq) / ciq
+          const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
           return [
             omega + sigSqToCiq * (score(qRank, iRank) - piq),
-            delta + ((gamma * sigSqToCiq) / ciq) * piq * (1 - piq),
+            delta + ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq),
           ]
         },
         [0, 0]

--- a/src/models/thurston-mosteller-part.js
+++ b/src/models/thurston-mosteller-part.js
@@ -5,7 +5,7 @@ import constants from '../constants'
 
 export default (game, options = {}) => {
   const { TWOBETASQ, EPSILON } = constants(options)
-  const { teamRating } = util(options)
+  const { teamRating, gamma } = util(options)
   const { vt, wt } = statistics(options)
   const teamRatings = teamRating(game)
   const adjacentTeams = ladderPairs(teamRatings)
@@ -19,13 +19,13 @@ export default (game, options = {}) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const deltaMu = (iMu - qMu) / ciq
           const sigSqToCiq = iSigmaSq / ciq
-          const gamma = Math.sqrt(iSigmaSq) / ciq
+          const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
-          /* istanbul ignore next */
           if (qRank === iRank) {
             return [
               omega + sigSqToCiq * vt(deltaMu, EPSILON / ciq),
-              delta + ((gamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq),
+              delta +
+                ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq),
             ]
           }
 
@@ -33,7 +33,7 @@ export default (game, options = {}) => {
           return [
             omega + sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq),
             delta +
-              ((gamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq),
+              ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq),
           ]
         },
         [0, 0]

--- a/src/util.js
+++ b/src/util.js
@@ -93,7 +93,13 @@ export const reorder = (rank) => (teams) => {
 export const transition = (postTeams, preTeams) =>
   preTeams.map((t) => postTeams.indexOf(t))
 
+export const gamma = (options) =>
+  options.gamma ??
+  // default to iSigma / ciq
+  ((ciq, _k, _mu, sigmaSq, _team, _qRank) => Math.sqrt(sigmaSq) / ciq)
+
 export default (options) => ({
   utilC: utilC(options),
   teamRating: teamRating(options),
+  gamma: gamma(options),
 })


### PR DESCRIPTION
Providing a different gamma function seems to increase accuracy of the Thurston-Mosteller model, e.g.

```js
rate(data, {
  model: 'thurstonMostellerFull',
  gamma: (_, k) => 1 / k
})
```