### PR TITLE
Revert "Bump to Node 16"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,12 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 10.x # maintainence ends 2021-04-30
+          - 11.x # deprecated
           - 12.x # maintainence ends 2022-04-30
+          - 13.x # deprecated
           - 14.x # maintainence ends 2023-04-30
-          - 16.x
+          - 15.x
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 14.x
       - run: npm install
       - run: npm run build --if-present
       - run: npm run test:coverage

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 16.3.0
+nodejs 14.4.0


### PR DESCRIPTION
Reverts philihp/openskill.js#171

Adds back in support for node 10 etc to avoid a major version bump.