### PR TITLE
chore(deps) update prettier/eslint package and configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "7.14.8",
     "@babel/preset-env": "7.14.9",
     "@babel/register": "7.14.5",
-    "@philihp/eslint-config": "4.3.0",
+    "@philihp/eslint-config": "5.0.0",
     "husky": "7.0.1",
     "lint-staged": "11.1.1",
     "prettier": "2.3.2"


### PR DESCRIPTION
Prettier rolled up a lot of packages and configuration into one and changed to a namespaced package. This should have no impact on the library itself.