### PR TITLE
feature: add predictDraw

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x # deprecated
           - 11.x # deprecated
           - 12.x # maintainence ends 2022-04-30
           - 13.x # deprecated

--- a/src/__tests__/predict-draw.test.js
+++ b/src/__tests__/predict-draw.test.js
@@ -1,0 +1,45 @@
+import { rating, predictDraw } from '..'
+
+describe('predictDraw', () => {
+  const precision = 6
+
+  const a1 = rating()
+  const a2 = rating({ mu: 32.444, sigma: 1.123 })
+
+  const b1 = rating({ mu: 35.881, sigma: 0.0001 })
+  const b2 = rating({ mu: 25.188, sigma: 1.421 })
+
+  const team1 = [a1, a2]
+  const team2 = [b1, b2]
+
+  it('if a tree falls in the forest', () => {
+    expect.assertions(1)
+    expect(predictDraw([])).toBeUndefined()
+  })
+
+  it('predicts 100% draw for solitaire', () => {
+    expect.assertions(1)
+    expect(predictDraw([team1])).toBeCloseTo(1, precision)
+  })
+
+  it('predicts 100% draw for self v self', () => {
+    expect.assertions(1)
+    expect(predictDraw([b1], [b1])).toBeCloseTo(1, precision)
+  })
+
+  it('predicts draw for two teams', () => {
+    expect.assertions(1)
+    expect(predictDraw([team1, team2])).toBeCloseTo(
+      0.1260703143635969,
+      precision
+    )
+  })
+
+  it('predicts draw for three asymmetric teams', () => {
+    expect.assertions(1)
+    expect(predictDraw([team1, team2, [a1], [a2], [b1]])).toBeCloseTo(
+      0.04322122887507519,
+      precision
+    )
+  })
+})

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ export const betaSq = (options) => beta(options) ** 2
 export default (options) => ({
   EPSILON: epsilon(options),
   TWOBETASQ: 2 * betaSq(options),
+  BETA: beta(options),
   BETASQ: betaSq(options),
   Z: z(options),
 })

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ import rating from './rating'
 import rate from './rate'
 import ordinal from './ordinal'
 import predictWin from './predict-win'
+import predictDraw from './predict-draw'
 
-export { rating, rate, ordinal, predictWin }
+export { rating, rate, ordinal, predictWin, predictDraw }

--- a/src/predict-draw.js
+++ b/src/predict-draw.js
@@ -1,0 +1,41 @@
+import constants from './constants'
+import util, { sum } from './util'
+import { phiMajor, phiMajorInverse } from './statistics'
+
+const predictWin = (teams, options = {}) => {
+  const { teamRating } = util(options)
+  const { BETASQ, BETA } = constants(options)
+
+  const n = teams.length
+  if (n === 0) return undefined
+  if (n === 1) return 1
+
+  const teamRatings = teamRating(teams)
+  const drawMargin =
+    Math.sqrt(teams.flat().length) * BETA * phiMajorInverse((1 + 1 / n) / 2)
+
+  const denom = (n * (n - 1)) / (n > 2 ? 1 : 2)
+
+  return (
+    Math.abs(
+      teamRatings
+        .map(([muA, sigmaSqA], i) =>
+          teamRatings
+            .filter((_, q) => i !== q)
+            .map(([muB, sigmaSqB]) => {
+              const sigmaBar = Math.sqrt(
+                n * BETASQ + sigmaSqA ** 2 + sigmaSqB ** 2
+              )
+              return (
+                phiMajor((drawMargin - muA + muB) / sigmaBar) -
+                phiMajor((muA - muB - drawMargin) / sigmaBar)
+              )
+            })
+        )
+        .flat()
+        .reduce(sum, 0)
+    ) / denom
+  )
+}
+
+export default predictWin

--- a/src/predict-win.js
+++ b/src/predict-win.js
@@ -1,5 +1,5 @@
 import constants from './constants'
-import util from './util'
+import util, { sum } from './util'
 import { phiMajor } from './statistics'
 
 const predictWin = (teams, options = {}) => {
@@ -10,15 +10,16 @@ const predictWin = (teams, options = {}) => {
   const n = teams.length
   const denom = (n * (n - 1)) / 2
 
-  return teamRatings.map(([muA, sigmaSqA], i) =>
-    teamRatings
-      .filter((_, q) => i !== q)
-      .map(([muB, sigmaSqB]) =>
-        phiMajor(
-          (muA - muB) / Math.sqrt(n * BETASQ + sigmaSqA ** 2 + sigmaSqB ** 2)
+  return teamRatings.map(
+    ([muA, sigmaSqA], i) =>
+      teamRatings
+        .filter((_, q) => i !== q)
+        .map(([muB, sigmaSqB]) =>
+          phiMajor(
+            (muA - muB) / Math.sqrt(n * BETASQ + sigmaSqA ** 2 + sigmaSqB ** 2)
+          )
         )
-      )
-      .reduce((a, b) => a + b / denom, 0)
+        .reduce(sum, 0) / denom
   )
 }
 

--- a/src/statistics.js
+++ b/src/statistics.js
@@ -5,6 +5,8 @@ const normal = gaussian(0, 1)
 
 export const phiMajor = (x) => normal.cdf(x)
 
+export const phiMajorInverse = (x) => normal.ppf(x)
+
 export const phiMinor = (x) => normal.pdf(x)
 
 export const v = (x, t) => {

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 import { zip } from 'ramda'
 import constants from './constants'
 
-const sum = (a, b) => a + b
+export const sum = (a, b) => a + b
 
 export const score = (q, i) => {
   if (q < i) {


### PR DESCRIPTION
This comes from @daegontaven's code at https://github.com/OpenDebates/openskill.py/blob/932e5029e1f9e0cd290defb102d777a6c9bd5879/openskill/rate.py#L237-L282

Seems pretty cool! 

Had to make a call to use the native [Array.prototype.flat()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat), which was only added after Node 11, or use the flat in Ramda that we already include, and figured I've (to this point) leaned toward using the native thing so I should continue to do that and Node 10 is out of EOL since last year anyway.