### PR TITLE
feature: use Ramda to add back Node 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 10.x # deprecated
           - 11.x # deprecated
           - 12.x # maintainence ends 2022-04-30
           - 13.x # deprecated

--- a/src/predict-draw.js
+++ b/src/predict-draw.js
@@ -1,3 +1,4 @@
+import { flatten } from 'ramda'
 import constants from './constants'
 import util, { sum } from './util'
 import { phiMajor, phiMajorInverse } from './statistics'
@@ -10,16 +11,15 @@ const predictWin = (teams, options = {}) => {
   if (n === 0) return undefined
   if (n === 1) return 1
 
+  const denom = (n * (n - 1)) / (n > 2 ? 1 : 2)
   const teamRatings = teamRating(teams)
   const drawMargin =
-    Math.sqrt(teams.flat().length) * BETA * phiMajorInverse((1 + 1 / n) / 2)
-
-  const denom = (n * (n - 1)) / (n > 2 ? 1 : 2)
+    Math.sqrt(flatten(teams).length) * BETA * phiMajorInverse((1 + 1 / n) / 2)
 
   return (
     Math.abs(
-      teamRatings
-        .map(([muA, sigmaSqA], i) =>
+      flatten(
+        teamRatings.map(([muA, sigmaSqA], i) =>
           teamRatings
             .filter((_, q) => i !== q)
             .map(([muB, sigmaSqB]) => {
@@ -32,8 +32,7 @@ const predictWin = (teams, options = {}) => {
               )
             })
         )
-        .flat()
-        .reduce(sum, 0)
+      ).reduce(sum, 0)
     ) / denom
   )
 }


### PR DESCRIPTION
While I prefer to use the Native stuff, I'd technically have to major version release to do that so I figure I can do this and release a minor version, then remove Node 11 support and do a major version... so here we go.