### PR TITLE
Remove support for Node 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x # deprecated
           - 11.x # deprecated
           - 12.x # maintainence ends 2022-04-30
           - 13.x # deprecated

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,8 @@ jobs:
           - 13.x # deprecated
           - 14.x # maintainence ends 2023-04-30
           - 15.x # deprecated
-          - 16.x
+          - 16.x # maintainence ends 2024-04-30
+          - 17.x # maintainence ends 2022-06-01
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3

--- a/src/__tests__/rate.test.js
+++ b/src/__tests__/rate.test.js
@@ -154,7 +154,7 @@ describe('rate', () => {
   it('runs a model whith ties for first', () => {
     expect.assertions(1)
     const [[w2], [x2], [y2], [z2]] = rate([[e1], [e1], [e1], [e1]], {
-      model: 'thurstonMostellerFull',
+      model: 'thurstoneMostellerFull',
       score: [100, 84, 100, 72],
     })
     expect([w2, x2, y2, z2]).toStrictEqual([

--- a/src/models/__tests__/index.test.js
+++ b/src/models/__tests__/index.test.js
@@ -47,7 +47,7 @@ describe('models#index', () => {
   it('runs TM full', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'thurstonMostellerFull',
+      model: 'thurstoneMostellerFull',
       epsilon: 0.1,
     })
     expect(a.mu).toBeCloseTo(33.461437)
@@ -60,7 +60,7 @@ describe('models#index', () => {
   it('runs TM partial', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'thurstonMostellerPart',
+      model: 'thurstoneMostellerPart',
       epsilon: 0.1,
       gamma: () => 1, // this is how it is in the source from Weng-Lin... mistake?
     })

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -8,8 +8,6 @@ export default {
   plackettLuce,
   bradleyTerryFull,
   bradleyTerryPart,
-  thurstonMostellerFull: thurstoneMostellerFull, // for compatibility with typo in earlier implementation
-  thurstonMostellerPart: thurstoneMostellerPart, // for compatibility with typo in earlier implementation
   thurstoneMostellerFull,
   thurstoneMostellerPart,
 }

--- a/src/predict-draw.js
+++ b/src/predict-draw.js
@@ -18,8 +18,8 @@ const predictWin = (teams, options = {}) => {
 
   return (
     Math.abs(
-      flatten(
-        teamRatings.map(([muA, sigmaSqA], i) =>
+      teamRatings
+        .map(([muA, sigmaSqA], i) =>
           teamRatings
             .filter((_, q) => i !== q)
             .map(([muB, sigmaSqB]) => {
@@ -32,7 +32,8 @@ const predictWin = (teams, options = {}) => {
               )
             })
         )
-      ).reduce(sum, 0)
+        .flat()
+        .reduce(sum, 0)
     ) / denom
   )
 }


### PR DESCRIPTION
* Removes support for Node 10
* Switches over to using the native Array.flat()
* Removes a typo'ed `thurstonMosteller`, missing the e.