### PR TITLE
feature: add tau option to rate

### DIFF
--- a/src/__tests__/rate.test.js
+++ b/src/__tests__/rate.test.js
@@ -176,4 +176,33 @@ describe('rate', () => {
       { mu: 25, sigma: 8.204837030780652 },
     ])
   })
+
+  it('accepts a tau term', () => {
+    expect.assertions(1)
+    const a = rating({ mu: 25, sigma: 3 })
+    const b = rating({ mu: 25, sigma: 3 })
+    const [[winner], [loser]] = rate([[a], [b]], {
+      tau: 0.3,
+    })
+
+    expect([winner, loser]).toStrictEqual([
+      { mu: 25.624880438870754, sigma: 2.9879993738476953 },
+      { mu: 24.375119561129246, sigma: 2.9879993738476953 },
+    ])
+  })
+
+  it('prevents sigma from rising', () => {
+    expect.assertions(1)
+    const a = rating({ mu: 40, sigma: 3 })
+    const b = rating({ mu: -20, sigma: 3 })
+    const [[winner], [loser]] = rate([[a], [b]], {
+      tau: 0.3,
+      preventSigmaIncrease: true,
+    })
+
+    expect([winner, loser]).toStrictEqual([
+      { mu: 40.00032667136128, sigma: 3 },
+      { mu: -20.000326671361275, sigma: 3 },
+    ])
+  })
 })

--- a/src/rate.js
+++ b/src/rate.js
@@ -1,24 +1,49 @@
-import { sortBy, identity } from 'ramda'
+import { sortBy, identity, range } from 'ramda'
 import unwind from 'sort-unwind'
 import models from './models'
 
 const rate = (teams, options = {}) => {
   const model = models[options.model || 'plackettLuce']
+  let processedTeams = teams
 
-  // if no rank or score provided, use natural ordering
-  if (options.rank === undefined && options.score === undefined) {
-    return model(teams, options)
+  // if tau is provided, use additive dynamics factor to prevent sigma from dropping too low.
+  // using this will ensure the rating will stay more pliable after many games
+  if (options.tau) {
+    const tauSquared = options.tau * options.tau
+    processedTeams = teams.map((team) =>
+      team.map((p) => ({
+        mu: p.mu,
+        sigma: Math.sqrt(p.sigma * p.sigma + tauSquared),
+      }))
+    )
   }
 
   // if rank provided, use it, otherwise transition scores and use that
-  const rank = options.rank ?? options.score?.map((points) => -points)
+  const rank =
+    options.rank ??
+    options.score?.map((points) => -points) ??
+    range(1, teams.length + 1)
 
-  const [orderedTeams, tenet] = unwind(rank, teams)
+  const [orderedTeams, tenet] = unwind(rank, processedTeams)
   const newRatings = model(orderedTeams, {
     ...options,
     rank: sortBy(identity, rank),
   })
-  const [reorderedTeams] = unwind(tenet, newRatings)
+  let [reorderedTeams] = unwind(tenet, newRatings)
+
+  // preventSigmaIncrease prevents sigma from ever going up which can happen when using a tau value.
+  // this helps prevent ordinal from ever dropping after winning a game which can feel unfair
+  if (options.tau && options.preventSigmaIncrease) {
+    reorderedTeams = reorderedTeams.map((team, i) =>
+      team.map((p, j) => {
+        const pOrig = teams[i][j]
+        return {
+          mu: p.mu,
+          sigma: p.sigma <= pOrig.sigma ? p.sigma : pOrig.sigma,
+        }
+      })
+    )
+  }
 
   return reorderedTeams
 }


### PR DESCRIPTION
This adds two new options to the rate function:
1. tau: The additive dynamics factor. Prevents sigma from getting too small to increase rating change volatility
2. preventSigmaIncrease: When paired with the tau option, prevents sigma from going up to prevent ordinal from dropping after a win, for example

The following example shows how a player's rating (ordinal) changes for games 0-100 as well as games 1800-1900 with and without tau applied. Note that in the late matches, ordinal without tau changes very minimally while ordinal with tau remains quite movable.
![image](https://user-images.githubusercontent.com/1534726/158310211-ff2134ac-78ed-4c5b-98f5-c41977cb3dfc.png)

Here is a graph of sigma as game are played (games 0-1900):
![image](https://user-images.githubusercontent.com/1534726/158310529-050dddb0-6aba-4ea9-8203-91c297598272.png)
