### PR TITLE
chore: update eslint/prettier/jest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 11.x # deprecated
           - 12.x # maintainence ends 2022-04-30
           - 13.x # deprecated
           - 14.x # maintainence ends 2023-04-30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,27 @@
 name: tests
 
-on: [push]
+on:
+  - push
 
 env:
   CI: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 17.x
+      - run: npm install
+      - run: npm run lint
+
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:
-          - 11.x # deprecated
           - 12.x # maintainence ends 2022-04-30
           - 13.x # deprecated
           - 14.x # maintainence ends 2023-04-30
@@ -26,7 +36,6 @@ jobs:
       - run: npm install
       - run: npm run build --if-present
       - run: npm test
-      - run: npm run lint
 
   coverage:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "7.17.5",
     "@babel/preset-env": "7.16.11",
     "@babel/register": "7.17.0",
-    "@philihp/eslint-config": "5.0.3",
+    "@philihp/eslint-config": "5.1.0",
     "husky": "7.0.4"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "7.17.5",
     "@babel/preset-env": "7.16.11",
     "@babel/register": "7.17.0",
-    "@philihp/eslint-config": "5.1.0",
+    "@philihp/eslint-config": "5.1.1",
     "husky": "7.0.4"
   },
   "lint-staged": {

--- a/src/__tests__/ordinal.test.js
+++ b/src/__tests__/ordinal.test.js
@@ -15,6 +15,6 @@ describe('ordinal', () => {
     const options = { z: 2 }
     const player = rating({ mu: 24.0, sigma: 6.0 }, options)
     const result = ordinal(player, options)
-    expect(result).toStrictEqual(12.0)
+    expect(result).toBe(12.0)
   })
 })


### PR DESCRIPTION
Bumps a bunch of devDependencies. Only one lint issue!

Splits out linting from tests, otherwise I'd lose support for 11.x