### PR TITLE
remove official support for node 11,12,13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 17.x
+          node-version: 18.x
       - run: npm install
       - run: npm run lint
 
@@ -22,9 +22,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 11.x # deprecated
-          - 12.x # deprecated
-          - 13.x # deprecated
           - 14.x # maintainence ends 2023-04-30
           - 15.x # deprecated
           - 16.x # maintainence ends 2024-04-30
@@ -45,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm install
       - run: npm run build --if-present
       - run: npm run test:coverage


### PR DESCRIPTION
Things may still work, YMMV... gonna stop testing it though, so Jest can upgrade.