### PR TITLE
feat!: change and document how models are passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This can be used in a similar way that you might use _quality_ in TrueSkill if y
 
 ### Alternative Models
 
-By default, we u se a Plackett-Luce model, which is probably good enough for most cases. When speed is an issue, the library runs faster with other models
+By default, we use a Plackett-Luce model, which is probably good enough for most cases. When speed is an issue, the library runs faster with other models
 
 ```js
 import { bradleyTerryFull } from './models'

--- a/README.md
+++ b/README.md
@@ -147,7 +147,16 @@ teams will draw. The number returned here should be treated as relative to other
 
 This can be used in a similar way that you might use _quality_ in TrueSkill if you were optimizing a matchmaking system, or optimizing an tournament tree structure for exciting finals and semi-finals such as in the NCAA.
 
-### Which Model do I want?
+### Alternative Models
+
+By default, we u se a Plackett-Luce model, which is probably good enough for most cases. When speed is an issue, the library runs faster with other models
+
+```js
+import { bradleyTerryFull } from './models'
+const [[a2],[b2]] = rate([[a1],[b1]], {
+  model: bradleyTerryFull,
+})
+```
 
 - Bradley-Terry rating models follow a logistic distribution over a player's skill, similar to Glicko.
 - Thurstone-Mosteller rating models follow a gaussian distribution, similar to TrueSkill. Gaussian CDF/PDF functions differ in implementation from system to system (they're all just chebyshev approximations anyway). The accuracy of this model isn't usually as great either, but tuning this with an alternative gamma function can improve the accuracy if you really want to get into it.

--- a/src/__tests__/rate.test.ts
+++ b/src/__tests__/rate.test.ts
@@ -1,4 +1,5 @@
 import { rate, rating } from '..'
+import thurstoneMostellerFull from '../models/thurstone-mosteller-full'
 
 describe('rate', () => {
   const a1 = rating({ mu: 29.182, sigma: 4.782 })
@@ -151,10 +152,10 @@ describe('rate', () => {
     ])
   })
 
-  it('runs a model whith ties for first', () => {
+  it('runs a model with ties for first', () => {
     expect.assertions(1)
     const [[w2], [x2], [y2], [z2]] = rate([[e1], [e1], [e1], [e1]], {
-      model: 'thurstoneMostellerFull',
+      model: thurstoneMostellerFull,
       score: [100, 84, 100, 72],
     })
     expect([w2, x2, y2, z2]).toStrictEqual([
@@ -175,6 +176,27 @@ describe('rate', () => {
       { mu: 25, sigma: 8.204837030780652 },
       { mu: 25, sigma: 8.204837030780652 },
     ])
+  })
+
+  it('accepts weights for partial play', () => {
+    expect.assertions(1)
+    expect(() =>
+      rate(
+        [
+          [a1, b1],
+          [c1, d1],
+        ],
+        {
+          // This is here to demonstrate how to send these in, although
+          // the default Plackett-Luce doesn't care.
+          // TODO: example with a custom model which takes this into account.
+          weight: [
+            [0.9, 1],
+            [1, 0.6],
+          ],
+        }
+      )
+    ).not.toThrow()
   })
 
   it('accepts a tau term', () => {

--- a/src/models/__tests__/bradley-terry-full-series.test.ts
+++ b/src/models/__tests__/bradley-terry-full-series.test.ts
@@ -1,4 +1,5 @@
 import { rate, rating } from '../..'
+import { bradleyTerryFull } from '..'
 
 // numbers in this test suite come from rank-1.02 based on 3 FFA games:
 // 0, 1, 2, 3, 4 with a score of 9, 7, 7, 5, 5
@@ -8,7 +9,7 @@ import { rate, rating } from '../..'
 describe('bradleyTerryFull#series', () => {
   it('runs as expected', () => {
     expect.assertions(10)
-    const model = 'bradleyTerryFull'
+    const model = bradleyTerryFull
     const p00 = rating()
     const p10 = rating()
     const p20 = rating()

--- a/src/models/__tests__/bradley-terry-part-series.test.ts
+++ b/src/models/__tests__/bradley-terry-part-series.test.ts
@@ -1,4 +1,5 @@
 import { rate, rating } from '../..'
+import { bradleyTerryPart } from '..'
 
 // numbers in this test suite come from rank-1.02 based on 3 FFA games:
 // 0, 1, 2, 3, 4 with a score of 9, 7, 7, 5, 5
@@ -8,7 +9,7 @@ import { rate, rating } from '../..'
 describe('bradleyTerryPart#series', () => {
   it('runs as expected', () => {
     expect.assertions(10)
-    const model = 'bradleyTerryPart'
+    const model = bradleyTerryPart
     const p00 = rating()
     const p10 = rating()
     const p20 = rating()

--- a/src/models/__tests__/index.test.ts
+++ b/src/models/__tests__/index.test.ts
@@ -1,4 +1,11 @@
 import { rate, rating } from '../..'
+import {
+  bradleyTerryFull,
+  bradleyTerryPart,
+  plackettLuce,
+  thurstoneMostellerFull,
+  thurstoneMostellerPart,
+} from '..'
 
 // numbers in this test suite come from rank-1.02 on a 3-way
 // these differ in that it uses an epsilon of 0.1
@@ -8,7 +15,7 @@ describe('models#index', () => {
   it('runs BT full', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'bradleyTerryFull',
+      model: bradleyTerryFull,
       epsilon: 0.1,
     })
     expect(a.mu).toBeCloseTo(30.270462767)
@@ -21,7 +28,7 @@ describe('models#index', () => {
   it('runs BT partial', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'bradleyTerryPart',
+      model: bradleyTerryPart,
       epsilon: 0.1,
     })
     expect(a.mu).toBeCloseTo(27.635231383)
@@ -34,7 +41,7 @@ describe('models#index', () => {
   it('runs PL', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'plackettLuce',
+      model: plackettLuce,
       epsilon: 0.1,
     })
     expect(a.mu).toBeCloseTo(27.8689)
@@ -47,7 +54,7 @@ describe('models#index', () => {
   it('runs TM full', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'thurstoneMostellerFull',
+      model: thurstoneMostellerFull,
       epsilon: 0.1,
     })
     expect(a.mu).toBeCloseTo(33.461437)
@@ -60,7 +67,7 @@ describe('models#index', () => {
   it('runs TM partial', () => {
     expect.assertions(6)
     const [[a], [b], [c]] = rate([[r], [r], [r]], {
-      model: 'thurstoneMostellerPart',
+      model: thurstoneMostellerPart,
       epsilon: 0.1,
       gamma: () => 1, // this is how it is in the source from Weng-Lin... mistake?
     })

--- a/src/models/__tests__/plackett-luce-series.test.ts
+++ b/src/models/__tests__/plackett-luce-series.test.ts
@@ -1,4 +1,5 @@
 import { rate, rating } from '../..'
+import { plackettLuce } from '..'
 
 // numbers in this test suite come from rank-1.02 based on 3 FFA games:
 // 0, 1, 2, 3, 4 with a score of 9, 7, 7, 5, 5
@@ -8,7 +9,7 @@ import { rate, rating } from '../..'
 describe('plackettLuce#series', () => {
   it('runs as expected', () => {
     expect.assertions(10)
-    const model = 'plackettLuce'
+    const model = plackettLuce
     const p00 = rating()
     const p10 = rating()
     const p20 = rating()

--- a/src/models/__tests__/thurstone-mosteller-full-series.test.ts
+++ b/src/models/__tests__/thurstone-mosteller-full-series.test.ts
@@ -1,4 +1,5 @@
 import { rate, rating } from '../..'
+import { thurstoneMostellerFull } from '..'
 
 // numbers in this test suite come from rank-1.02 based on 3 FFA games:
 // 0, 1, 2, 3, 4 with a score of 9, 7, 7, 5, 5
@@ -8,7 +9,7 @@ import { rate, rating } from '../..'
 describe('thurstoneMostellerFull#series', () => {
   it('runs as expected', () => {
     expect.assertions(10)
-    const model = 'thurstoneMostellerFull'
+    const model = thurstoneMostellerFull
     const p00 = rating()
     const p10 = rating()
     const p20 = rating()

--- a/src/models/__tests__/thurstone-mosteller-part-series.test.ts
+++ b/src/models/__tests__/thurstone-mosteller-part-series.test.ts
@@ -1,4 +1,5 @@
 import { rate, rating } from '../..'
+import { thurstoneMostellerPart } from '..'
 
 // numbers in this test suite come from rank-1.02 based on 3 FFA games:
 // 0, 1, 2, 3, 4 with a score of 9, 7, 7, 5, 5
@@ -8,7 +9,7 @@ import { rate, rating } from '../..'
 describe('thurstoneMostellerPart#series', () => {
   it('runs as expected', () => {
     expect.assertions(10)
-    const model = 'thurstoneMostellerPart'
+    const model = thurstoneMostellerPart
     const p00 = rating()
     const p10 = rating()
     const p20 = rating()

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,7 +4,7 @@ import bradleyTerryPart from './bradley-terry-part'
 import thurstoneMostellerFull from './thurstone-mosteller-full'
 import thurstoneMostellerPart from './thurstone-mosteller-part'
 
-export default {
+export {
   plackettLuce,
   bradleyTerryFull,
   bradleyTerryPart,

--- a/src/rate.ts
+++ b/src/rate.ts
@@ -1,10 +1,10 @@
 import { sortBy, identity, range } from 'ramda'
 import unwind from 'sort-unwind'
-import models from './models'
+import { plackettLuce } from './models'
 import { Rating, Options } from './types'
 
-const rate = (teams: Rating[][], options: Options = {}) => {
-  const model = models[options.model || 'plackettLuce']
+const rate = (teams: Rating[][], options: Options = {}): Rating[][] => {
+  const model = options.model ?? plackettLuce
   let processedTeams = teams
 
   // if tau is provided, use additive dynamics factor to prevent sigma from dropping too low.

--- a/src/rating.ts
+++ b/src/rating.ts
@@ -1,7 +1,7 @@
 import { mu as defaultMu, sigma as defaultSigma } from './constants'
 import { Rating } from './types'
 
-const rating = (init?: Rating, options = {}) => ({
+const rating = (init?: Rating, options = {}): Rating => ({
   mu: init?.mu ?? defaultMu(options),
   sigma: init?.sigma ?? defaultSigma({ ...options, mu: init?.mu }),
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,23 +3,29 @@ export type Rating = {
   sigma: number
 }
 
-export type Model =
-  | 'thurstoneMostellerPart'
-  | 'thurstoneMostellerFull'
-  | 'bradleyTerryPart'
-  | 'bradleyTerryFull'
-  | 'plackettLuce'
+export type Gamma = (
+  c: number,
+  k: number,
+  mu: number,
+  sigmaSq: number,
+  team: Rating[],
+  qRank: number
+) => number
+
+// eslint-disable-next-line no-use-before-define
+export type Model = (teams: Rating[][], options: Options) => Rating[][]
 
 export type Options = {
   z?: number
   mu?: number
   sigma?: number
   epsilon?: number
-  gamma?: number
+  gamma?: () => number
   beta?: number
   model?: Model
   rank?: number[]
   score?: number[]
+  weight?: number[][]
   tau?: number
   preventSigmaIncrease?: boolean
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { zip } from 'ramda'
 import constants from './constants'
-import { Rating, Options } from './types'
+import { Rating, Options, Gamma } from './types'
 
 type TeamRating = [number, number, Rating[], number]
 
@@ -85,7 +85,7 @@ export const utilA = (teamRatings: TeamRating[]) =>
         .length
   )
 
-export const gamma = (options: Options) =>
+export const gamma = (options: Options): Gamma =>
   options.gamma ??
   // default to iSigma / c
   ((


### PR DESCRIPTION
This changes the way the user can request a different model, and also opens the door for users to experiment with models which take into account a weight from partial play, which is a common request (see #272 and #179, https://github.com/OpenDebates/openskill.py/issues/29).

Also adds a Typescript type for Gamma and Model.