### PR TITLE
update eslint config to new flat style

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,27 @@
-module.exports = []
+import eslint from '@eslint/js'
+import jestPlugin from 'eslint-plugin-jest'
+import tseslint from 'typescript-eslint'
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
+
+export default tseslint.config(
+  {
+    // config with just ignores is the replacement for `.eslintignore`
+    files: ['src/**/*.ts'],
+    ignores: ['**/dist/**', '**/benchmark/**', 'eslint.config.js'],
+    extends: [eslint.configs.recommended, eslintPluginPrettierRecommended, ...tseslint.configs.recommended],
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/**/__tests__/*.ts', 'src/**/*.test.ts'],
+    extends: [jestPlugin.configs['flat/recommended']],
+  }
+)

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/recommended": "1.0.6",
     "@types/jest": "29.5.12",
-    "eslint": "^8.57.0",
-    "eslint-plugin-jest": "^28.2.0",
-    "eslint-plugin-prettier": "^5.1.3",
+    "eslint": "8.57.0",
+    "eslint-plugin-jest": "28.2.0",
+    "eslint-plugin-prettier": "5.1.3",
     "husky": "9.0.11",
     "jest": "29.7.0",
-    "typescript": "^5.4.5",
-    "typescript-eslint": "^7.7.1"
+    "typescript": "5.4.5",
+    "typescript-eslint": "7.7.1"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json}": [
@@ -66,6 +66,7 @@
   "dependencies": {
     "@types/gaussian": "1.2.2",
     "@types/ramda": "0.29.12",
+    "eslint-config-prettier": "9.1.0",
     "gaussian": "1.3.0",
     "ramda": "0.29.1",
     "sort-unwind": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "build": "npm run build:typescript && npm run build:babel",
     "build:babel": "babel src --out-dir dist --extensions \".js,.ts\" --source-maps inline",
     "build:typescript": "tsc --emitDeclarationOnly",
-    "lint": "eslint",
+    "lint": "eslint .",
     "prepare": "husky & npm run build",
     "release": "np",
     "test": "jest",
     "test:coverage": "npm run test -- --coverage"
   },
+  "type": "module",
   "main": "./dist/index.js",
   "files": [
     "/dist",
@@ -39,14 +40,17 @@
     "@babel/preset-env": "7.24.4",
     "@babel/preset-typescript": "7.24.1",
     "@babel/register": "7.23.7",
+    "@eslint/js": "9.1.1",
     "@philihp/prettier-config": "1.0.0",
-    "@tsconfig/node20": "20.1.4",
+    "@tsconfig/recommended": "1.0.6",
     "@types/jest": "29.5.12",
-    "eslint": "9.1.0",
-    "eslint-plugin-jest": "28.2.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-jest": "^28.2.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "husky": "9.0.11",
     "jest": "29.7.0",
-    "typescript": "5.4.5"
+    "typescript": "^5.4.5",
+    "typescript-eslint": "^7.7.1"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json}": [

--- a/src/__tests__/rate.test.ts
+++ b/src/__tests__/rate.test.ts
@@ -37,11 +37,11 @@ describe('rate', () => {
       [{ mu: 30.20997558824299, sigma: 4.764909330988368 }],
       [{ mu: 27.64461002009721, sigma: 4.882799245921361 }],
       [{ mu: 17.403587237635527, sigma: 6.100731158882956 }],
-      [{ mu: 19.21478808745494, sigma: 7.854267281042293 }]
+      [{ mu: 19.21478808745494, sigma: 7.854267281042293 }],
     ])
   })
 
-  it("rate accepts and runs a placket-luce model with tau and prevent_sigma_increase", () => {
+  it('rate accepts and runs a placket-luce model with tau and prevent_sigma_increase', () => {
     expect.assertions(2)
     const a1 = rating({ mu: 6.672, sigma: 0.0001 })
     const b1 = rating({ mu: 29.182, sigma: 4.782 })
@@ -51,50 +51,64 @@ describe('rate', () => {
     expect(a2.sigma).toBeLessThanOrEqual(a1.sigma)
     expect([[a2], [b2]]).toStrictEqual([
       [{ mu: 6.672012533190158, sigma: 0.0001 }],
-      [{ mu: 26.316243774876106, sigma: 4.7540633621019 }]
+      [{ mu: 26.316243774876106, sigma: 4.7540633621019 }],
     ])
   })
 
-
-  it("rate accepts and runs a placket-luce model by default for teams", () => {
+  it('rate accepts and runs a placket-luce model by default for teams', () => {
     const a1 = rating({ mu: 29.182, sigma: 4.782 })
     const b1 = rating({ mu: 27.174, sigma: 4.922 })
     const c1 = rating({ mu: 16.672, sigma: 6.217 })
     const d1 = rating()
 
-    const [[a2, b2], [c2, d2]] = rate([[a1, b1], [c1, d1]])
+    const [[a2, b2], [c2, d2]] = rate([
+      [a1, b1],
+      [c1, d1],
+    ])
 
     expect([a2, b2, c2, d2]).toStrictEqual([
       { mu: 29.607218266047376, sigma: 4.754597315295896 },
       { mu: 27.624480490655575, sigma: 4.89211428863373 },
       { mu: 15.953288649990139, sigma: 6.125357588584119 },
-      { mu: 23.708690706816785, sigma: 8.111298027437888 }
+      { mu: 23.708690706816785, sigma: 8.111298027437888 },
     ])
   })
 
-  it("rate accepts and runs a placket-luce model by default for teams with tau", () => {
+  it('rate accepts and runs a placket-luce model by default for teams with tau', () => {
     const a1 = rating({ mu: 29.182, sigma: 4.782 })
     const b1 = rating({ mu: 27.174, sigma: 4.922 })
     const c1 = rating({ mu: 16.672, sigma: 6.217 })
     const d1 = rating()
 
-    const [[a2, b2], [c2, d2]] = rate([[a1, b1], [c1, d1]], { tau: 0.01 })
+    const [[a2, b2], [c2, d2]] = rate(
+      [
+        [a1, b1],
+        [c1, d1],
+      ],
+      { tau: 0.01 }
+    )
 
     expect([a2, b2, c2, d2]).toStrictEqual([
       { mu: 29.60722003260825, sigma: 4.754607604502581 },
       { mu: 27.624482251695827, sigma: 4.892124276331747 },
       { mu: 15.953286947567106, sigma: 6.1253654293947335 },
-      { mu: 23.708689129525133, sigma: 8.111303923213725 }
+      { mu: 23.708689129525133, sigma: 8.111303923213725 },
     ])
   })
 
-  it("rate accepts and runs a placket-luce model by default for teams with tau and prevent_sigma_increase", () => {
+  it('rate accepts and runs a placket-luce model by default for teams with tau and prevent_sigma_increase', () => {
     const a1 = rating({ mu: 9.182, sigma: 0.0001 })
     const b1 = rating({ mu: 27.174, sigma: 4.922 })
     const c1 = rating({ mu: 16.672, sigma: 6.217 })
     const d1 = rating()
 
-    const [[a2, b2], [c2, d2]] = rate([[a1, b1], [c1, d1]], { tau: 0.01, preventSigmaIncrease: true })
+    const [[a2, b2], [c2, d2]] = rate(
+      [
+        [a1, b1],
+        [c1, d1],
+      ],
+      { tau: 0.01, preventSigmaIncrease: true }
+    )
 
     expect(a2.sigma).toBeLessThanOrEqual(a1.sigma)
 
@@ -102,7 +116,7 @@ describe('rate', () => {
       { mu: 9.182004653636957, sigma: 0.0001 },
       { mu: 28.301285923165363, sigma: 4.889318394468611 },
       { mu: 14.87349383521136, sigma: 6.076727029758966 },
-      { mu: 21.768626152890867, sigma: 7.992333183226455 }
+      { mu: 21.768626152890867, sigma: 7.992333183226455 },
     ])
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true


### PR DESCRIPTION
Eslint 9 will have a new eslint.config.js file format. This gets us there, but typescript-eslint doesn't yet support 9.