### PR TITLE
fix: lint-staged should run prettier

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,6 @@
+export default {
+  "src/**/*.{ts,tsx,js,jsx,json}": [
+    "prettier --write",
+    "eslint --fix",
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -54,11 +54,6 @@
     "typescript": "5.5.2",
     "typescript-eslint": "7.14.1"
   },
-  "lint-staged": {
-    "src/**/*.{js,jsx,json}": [
-      "eslint --fix"
-    ]
-  },
   "prettier": "@philihp/prettier-config",
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
eslint-plugin-prettier is no longer the preferred thing, and now it's [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) instead, and just run the two as their own step, rather than prettier inside of eslint. this is probably less fragile, idk.

also lololol wtf my lint-staged config was only globbing *.js? okay, me.