### PR TITLE
fix: eslint bug with no-use-before-define no longer errors

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ export type Rank = number
 
 export type Gamma = (c: number, k: number, mu: number, sigmaSq: number, team: Rating[], qRank: number) => number
 
-// eslint-disable-next-line no-use-before-define
 export type Model = (teams: Team[], options?: Options) => Team[]
 
 export type Options = {


### PR DESCRIPTION
no longer need to ignore no-use-before-define