### PR TITLE
fix: bump sort-unwind to verson without default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "@types/ramda": "0.30.1",
     "gaussian": "1.3.0",
     "ramda": "0.30.1",
-    "sort-unwind": "3.0.1"
+    "sort-unwind": "3.1.0"
   }
 }

--- a/src/rate.ts
+++ b/src/rate.ts
@@ -1,5 +1,5 @@
 import { sortBy, identity, range } from 'ramda'
-import unwind from 'sort-unwind'
+import { unwind } from 'sort-unwind'
 
 import { Rating, Options, Team } from './types'
 import constants from './constants'


### PR DESCRIPTION
I believe there's an issue with the way default exports in CJS is weird, shown with the example in https://github.com/philihp/openskill.js/issues/627#issuecomment-2237978221

I added a named export to sort-unwind, so that should work around this. If that doesn't work, I think there's a tsconfig option that can be flipped (https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html), but I don't fully understand the implications of that, and another alternative would be to inline sort-unwind, but I'd prefer to keep modules smaller.