### PR TITLE
build: build and lint with node 22.5.1+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 22.4.1
       - run: npm install
       - run: npm run lint
 
@@ -29,8 +27,7 @@ jobs:
         node-version:
           - 18.x # until 2025-04-30
           - 20.x # until 2026-04-30
-          - 22.4.1 # until 2027-04-30
-          # temporary to 22.4.1 to fix node build problem
+          - 22.x # until 2027-04-30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -45,8 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 22.4.1
       - run: npm install
       - run: npm run build --if-present
       - run: npm run test:coverage


### PR DESCRIPTION
node 22.5.0 had a problem, but 22.5.1 is now out, fixing it