### PR TITLE
Update ordinal.ts to match Python version

### DIFF
--- a/src/__tests__/ordinal.test.ts
+++ b/src/__tests__/ordinal.test.ts
@@ -12,9 +12,10 @@ describe('ordinal', () => {
 
   it('respects alpha and target parameters', () => {
     expect.assertions(1)
-    const player = rating({ mu: 24.0, sigma: 6.0 })
     // Mimic ELO range (alpha = 200 / sigma = 200 / (25 / 3))
-    const result = ordinal(player, 24.0, 1500.0)
+    const options = { alpha: 24.0, target: 1500.0 }
+    const player = rating({ mu: 24.0, sigma: 6.0 })
+    const result = ordinal(player, options)
     expect(result).toBe(1644.0)
   })
 

--- a/src/__tests__/ordinal.test.ts
+++ b/src/__tests__/ordinal.test.ts
@@ -10,6 +10,14 @@ describe('ordinal', () => {
     expect(result).toBe(-1.0)
   })
 
+  it('respects alpha and target parameters', () => {
+    expect.assertions(1)
+    const player = rating({ mu: 24.0, sigma: 6.0 })
+    // Mimic ELO range (alpha = 200 / sigma = 200 / (25 / 3))
+    const result = ordinal(player, 24.0, 1500.0)
+    expect(result).toBe(1644.0)
+  })
+
   it('respects a custom Z', () => {
     expect.assertions(1)
     const options = { z: 2 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ import { Options } from './types'
 
 const builder = (options: Options) => {
   // i'd love to know of a better way to do this
-  const { z = 3, mu = 25, preventSigmaIncrease = false, epsilon = 0.0001 } = options
+  const { z = 3, mu = 25, preventSigmaIncrease = false, epsilon = 0.0001, alpha = 1, target = 0 } = options
   const { tau = mu / 300, sigma = mu / z, beta = sigma / 2, limitSigma = preventSigmaIncrease } = options
   const betaSq = beta ** 2
 
@@ -14,6 +14,8 @@ const builder = (options: Options) => {
     BETA: beta,
     BETASQ: betaSq,
     Z: z,
+    ALPHA: alpha,
+    TARGET: target,
     TAU: tau,
     LIMIT_SIGMA: limitSigma,
   }

--- a/src/ordinal.ts
+++ b/src/ordinal.ts
@@ -10,10 +10,10 @@ import { Rating, Options } from './types'
  * options.Z: controls how many standard deviations below μ you want
  *            (3 ⇒ ≈ 99.7 % confidence).
  */
-const ordinal = (rating: Rating, alpha = 1, target = 0, options: Options = {}): number => {
+const ordinal = (rating: Rating, options: Options = {}): number => {
   const { sigma, mu } = rating
-  const { Z } = constants(options)
-  return alpha * ((mu - Z * sigma) + target / alpha);
+  const { Z, ALPHA, TARGET } = constants(options)
+  return ALPHA * (mu - Z * sigma + TARGET / ALPHA)
 }
 
 export default ordinal

--- a/src/ordinal.ts
+++ b/src/ordinal.ts
@@ -1,10 +1,19 @@
 import constants from './constants'
 import { Rating, Options } from './types'
 
-const ordinal = (rating: Rating, options: Options = {}): number => {
+/**
+ * Compute a conservative "ordinal" skill estimate:
+ *   α · [ (μ − z·σ) + target / α ]
+ *
+ * alpha: scales the entire metric.
+ * target: shifts the baseline toward a desired floor/goal.
+ * options.Z: controls how many standard deviations below μ you want
+ *            (3 ⇒ ≈ 99.7 % confidence).
+ */
+const ordinal = (rating: Rating, alpha = 1, target = 0, options: Options = {}): number => {
   const { sigma, mu } = rating
   const { Z } = constants(options)
-  return mu - Z * sigma
+  return alpha * ((mu - Z * sigma) + target / alpha);
 }
 
 export default ordinal

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export type Options = {
   score?: number[]
   weight?: number[][]
   tau?: number
+  alpha?: number
+  target?: number
   preventSigmaIncrease?: boolean // deprecated, use limitSigma, this will go away someday
   limitSigma?: boolean
 }


### PR DESCRIPTION
From the Python docs: While there is no one-to-one correspondence between Elo and OpenSkill, one standard deviation is approximately equivalent to around 200 points for an Elo rating starting at around 1500. To mimic Elo, simply set alpha to 200/sigma and target to 1500 for ordinal().