### PR TITLE
feat: add margin option to rate()

### DIFF
--- a/src/__tests__/margin.test.ts
+++ b/src/__tests__/margin.test.ts
@@ -28,20 +28,16 @@ describe('margin', () => {
 
   it('winner gains more mu with a large margin than without', () => {
     expect.assertions(1)
-    const [[winner], [loser]] = rate([[a], [b]], { score: [10, 0] })
-    const [[winnerM], [loserM]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
+    const [[winner]] = rate([[a], [b]], { score: [10, 0] })
+    const [[winnerM]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
     expect(winnerM.mu).toBeGreaterThan(winner.mu)
-    void loser
-    void loserM
   })
 
   it('loser loses more mu with a large margin than without', () => {
     expect.assertions(1)
-    const [[winner], [loser]] = rate([[a], [b]], { score: [10, 0] })
-    const [[winnerM], [loserM]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
+    const [, [loser]] = rate([[a], [b]], { score: [10, 0] })
+    const [, [loserM]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
     expect(loserM.mu).toBeLessThan(loser.mu)
-    void winner
-    void winnerM
   })
 
   it('differences within the margin threshold are not amplified', () => {
@@ -70,12 +66,10 @@ describe('margin', () => {
   it('three-team ffa: winner benefits most from large margin', () => {
     expect.assertions(2)
     const c = rating()
-    const [[w1], [p2], [l1]] = rate([[a], [b], [c]], { score: [10, 5, 0] })
-    const [[w2], [p2m], [l2]] = rate([[a], [b], [c]], { score: [10, 5, 0], margin: 1 })
+    const [[w1], , [l1]] = rate([[a], [b], [c]], { score: [10, 5, 0] })
+    const [[w2], , [l2]] = rate([[a], [b], [c]], { score: [10, 5, 0], margin: 1 })
     expect(w2.mu).toBeGreaterThan(w1.mu)
     expect(l2.mu).toBeLessThan(l1.mu)
-    void p2
-    void p2m
   })
 
   it('margin is compatible with tau', () => {

--- a/src/__tests__/margin.test.ts
+++ b/src/__tests__/margin.test.ts
@@ -1,0 +1,99 @@
+import { rate, rating } from '..'
+
+describe('margin', () => {
+  const a = rating()
+  const b = rating()
+
+  it('no margin produces the same result as omitting margin', () => {
+    expect.assertions(1)
+    const withoutMargin = rate([[a], [b]], { score: [10, 5] })
+    const withZeroMargin = rate([[a], [b]], { score: [10, 5], margin: 0 })
+    expect(withoutMargin).toStrictEqual(withZeroMargin)
+  })
+
+  it('margin with no score has no effect', () => {
+    expect.assertions(1)
+    const withoutMargin = rate([[a], [b]])
+    const withMarginNoScore = rate([[a], [b]], { margin: 5 })
+    expect(withoutMargin).toStrictEqual(withMarginNoScore)
+  })
+
+  it('does not mutate input ratings', () => {
+    expect.assertions(2)
+    const before = { mu: a.mu, sigma: a.sigma }
+    rate([[a], [b]], { score: [10, 0], margin: 5 })
+    expect(a.mu).toBe(before.mu)
+    expect(a.sigma).toBe(before.sigma)
+  })
+
+  it('winner gains more mu with a large margin than without', () => {
+    expect.assertions(1)
+    const [[winner], [loser]] = rate([[a], [b]], { score: [10, 0] })
+    const [[winnerM], [loserM]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
+    expect(winnerM.mu).toBeGreaterThan(winner.mu)
+    void loser
+    void loserM
+  })
+
+  it('loser loses more mu with a large margin than without', () => {
+    expect.assertions(1)
+    const [[winner], [loser]] = rate([[a], [b]], { score: [10, 0] })
+    const [[winnerM], [loserM]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
+    expect(loserM.mu).toBeLessThan(loser.mu)
+    void winner
+    void winnerM
+  })
+
+  it('differences within the margin threshold are not amplified', () => {
+    expect.assertions(2)
+    const [[w1], [l1]] = rate([[a], [b]], { score: [5, 3] })
+    const [[w2], [l2]] = rate([[a], [b]], { score: [5, 3], margin: 10 })
+    expect(w1.mu).toBeCloseTo(w2.mu, 10)
+    expect(l1.mu).toBeCloseTo(l2.mu, 10)
+  })
+
+  it('larger margins produce proportionally larger updates', () => {
+    expect.assertions(2)
+    const [[w1]] = rate([[a], [b]], { score: [10, 0], margin: 5 })
+    const [[w2]] = rate([[a], [b]], { score: [20, 0], margin: 5 })
+    expect(w2.mu).toBeGreaterThan(w1.mu)
+    const [[w3]] = rate([[a], [b]], { score: [100, 0], margin: 5 })
+    expect(w3.mu).toBeGreaterThan(w2.mu)
+  })
+
+  it('margin scaling is symmetric: winner gain equals loser loss', () => {
+    expect.assertions(1)
+    const [[w], [l]] = rate([[a], [b]], { score: [10, 0], margin: 1 })
+    expect(w.mu + l.mu).toBeCloseTo(a.mu + b.mu, 10)
+  })
+
+  it('three-team ffa: winner benefits most from large margin', () => {
+    expect.assertions(2)
+    const c = rating()
+    const [[w1], [p2], [l1]] = rate([[a], [b], [c]], { score: [10, 5, 0] })
+    const [[w2], [p2m], [l2]] = rate([[a], [b], [c]], { score: [10, 5, 0], margin: 1 })
+    expect(w2.mu).toBeGreaterThan(w1.mu)
+    expect(l2.mu).toBeLessThan(l1.mu)
+    void p2
+    void p2m
+  })
+
+  it('margin is compatible with tau', () => {
+    expect.assertions(1)
+    expect(() => rate([[a], [b]], { score: [10, 0], margin: 3, tau: 0.3 })).not.toThrow()
+  })
+
+  it('margin is compatible with limitSigma', () => {
+    expect.assertions(1)
+    expect(() => rate([[a], [b]], { score: [10, 0], margin: 3, tau: 0.3, limitSigma: true })).not.toThrow()
+  })
+
+  it('exact values with margin=5, scores=[10,0]', () => {
+    expect.assertions(2)
+    const [[w], [l]] = rate([[a], [b]], { score: [10, 0], margin: 5 })
+    // factor = 1 + log1p(max(0, 10 - 5)) / 1 = 1 + log1p(5) ≈ 2.7917
+    // winner mu change is amplified by that factor
+    expect(w.mu).toBeGreaterThan(25)
+    expect(l.mu).toBeLessThan(25)
+  })
+})

--- a/src/rate.ts
+++ b/src/rate.ts
@@ -32,6 +32,28 @@ const rate = (teams: Team[], options: Options = {}): Team[] => {
   })
   let [reorderedTeams] = unwind(tenet, newRatings)
 
+  // margin amplifies rating updates when scores are provided and a team's score differs
+  // from opponents by more than the margin threshold. Larger victory margins yield
+  // proportionally larger mu changes via log1p, while differences within the margin
+  // are treated as ordinary wins/losses.
+  if (options.score && options.margin) {
+    const scores = options.score
+    const margin = options.margin
+    const n = teams.length
+    reorderedTeams = reorderedTeams.map((team: Rating[], i: number) => {
+      const factor =
+        1 +
+        scores.reduce((acc, sj, j) => {
+          if (j === i) return acc
+          return acc + Math.log1p(Math.max(0, Math.abs(scores[i] - sj) - margin)) / (n - 1)
+        }, 0)
+      return team.map((p: Rating, k: number) => ({
+        mu: processedTeams[i][k].mu + factor * (p.mu - processedTeams[i][k].mu),
+        sigma: p.sigma,
+      }))
+    })
+  }
+
   // limitSigma prevents sigma from ever going up which can happen when using a tau value.
   // this helps prevent ordinal from ever dropping after winning a game which can feel unfair
   if (TAU && LIMIT_SIGMA) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Options = {
   score?: number[]
   weight?: number[][]
   tau?: number
+  margin?: number
   alpha?: number
   target?: number
   preventSigmaIncrease?: boolean // deprecated, use limitSigma, this will go away someday


### PR DESCRIPTION
## Summary

- Adds `margin?: number` to the `Options` type
- When `score` is provided alongside `margin`, rating updates are amplified based on how much each score difference exceeds the threshold
- Ported from `openskill.py` (added in v6.1.0) which has the equivalent `margin` constructor parameter

## Design

The amplification factor for team `i` is:

```
factor = 1 + Σⱼ log1p(max(0, |score[i] − score[j]| − margin)) / (n − 1)
```

This factor is always ≥ 1 and is applied to scale the mu delta that the model already computed — sigma is unchanged. Key properties:

- Score differences **within** the margin threshold: factor = 1, no amplification
- Score differences **above** the threshold: factor grows logarithmically, so large margins matter but don't dominate
- Applies symmetrically: the winner's gain and the loser's loss are both amplified, so `Σ mu` is conserved
- Zero or absent `margin` with `score`: identical to current behaviour

```ts
import { rate, rating } from 'openskill'

const a = rating()
const b = rating()

// margin=5: a score gap of >5 amplifies the update
const [[winner], [loser]] = rate([[a], [b]], { score: [10, 0], margin: 5 })
// winner gains more mu than a plain score: [10, 0] call would give
```

## Test plan

- [ ] `margin: 0` produces the same result as omitting margin
- [ ] `margin` without `score` has no effect
- [ ] Input ratings are not mutated
- [ ] Winner gains more mu with a large margin than without
- [ ] Loser loses more mu with a large margin than without
- [ ] Differences within the margin threshold are not amplified
- [ ] Larger score gaps produce proportionally larger updates (logarithmic growth)
- [ ] `Σ mu` is conserved (winner gain = loser loss)
- [ ] Compatible with `tau` and `limitSigma`

https://claude.ai/code/session_0151N9fApDLeHnrhRj1tu3p2

---
_Generated by [Claude Code](https://claude.ai/code/session_0151N9fApDLeHnrhRj1tu3p2)_