### PR TITLE
test: regression tests for PlackettLuce tie handling (closes #879)

### DIFF
--- a/src/models/__tests__/plackett-luce.test.ts
+++ b/src/models/__tests__/plackett-luce.test.ts
@@ -64,4 +64,20 @@ describe('plackettLuce', () => {
       ],
     ])
   })
+
+  it('2-player tie with equal ratings does not change mu', () => {
+    expect.assertions(2)
+    const [[x], [y]] = rate([team1, team1], { rank: [1, 1] })
+    expect(x.mu).toBeCloseTo(25)
+    expect(y.mu).toBeCloseTo(25)
+  })
+
+  it('2-player tie with unequal ratings: stronger loses mu, weaker gains mu', () => {
+    expect.assertions(2)
+    const strong = [rating({ mu: 35, sigma: 8 })]
+    const weak = [rating({ mu: 15, sigma: 8 })]
+    const [[s2], [w2]] = rate([strong, weak], { rank: [1, 1] })
+    expect(s2.mu).toBeLessThan(35)
+    expect(w2.mu).toBeGreaterThan(15)
+  })
 })


### PR DESCRIPTION
## Summary

- Investigated whether the JS library is affected by the tie-handling bug found in `openskill.py` [PR #176](https://github.com/vivekjoshy/openskill.py/pull/176)
- **Conclusion: the JS library is not affected.** The Python bug used rank equality (`team_q.rank == team_i.rank`) to identify the self-term in the Plackett-Luce summation, which incorrectly fired for all tied teams. The JS code correctly uses index equality (`i === q`) at `src/models/plackett-luce.ts:21`.
- Added two regression tests to `src/models/__tests__/plackett-luce.test.ts` to lock in correct behavior

## New Tests

1. **Equal-rated 2-player tie → mu unchanged**: directly replicates the Python bug scenario. If the self-term check were wrong, both players would gain mu instead of staying at 25.
2. **Unequal-rated 2-player tie → stronger loses, weaker gains**: verifies expected behavior when a stronger player ties a weaker one.

## Test Plan

- [x] Existing tests still pass
- [x] New tie tests pass with current implementation
- [x] Manually verified the math: for equal-rated 2-player tie, `omegaSum = (1-0.5)/2 + (-0.5)/2 = 0`, so mu stays unchanged ✓

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)