### PR TITLE
chore(deps): upgrade TypeScript to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc --declaration --emitDeclarationOnly --rootDir src --outDir dist && for f in $(find dist -name '*.d.ts' ! -name '*.d.cts'); do cp \"$f\" \"${f%.d.ts}.d.cts\"; done",
     "lint": "eslint .",
     "prepare": "husky && npm run build",
     "release": "np",
@@ -64,8 +64,8 @@
     "jest": "30.3.0",
     "lint-staged": "16.4.0",
     "tsup": "8.5.1",
-    "typescript": "5.9.3",
-    "typescript-eslint": "8.59.1"
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.59.2"
   },
   "prettier": "@philihp/prettier-config",
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": ["./src/**/__tests__/**", "./src/**/*.test.*"]
 }

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/", "!src/**/__tests__/**", "!src/**/*.test.*"],
   splitting: false,
   sourcemap: "inline",
-  dts: true,
+  dts: false,
   clean: true,
   format: ["cjs","esm"]
 })


### PR DESCRIPTION
## Summary

- Upgrades `typescript` from `5.9.3` to `6.0.3`
- Moves DTS generation from tsup's built-in `rollup-plugin-dts` (which hardcodes `baseUrl: "."`) to `tsc --emitDeclarationOnly`, eliminating the `baseUrl` deprecation at the source rather than suppressing it
- Adds a copy step to mirror `.d.ts` → `.d.cts` for the CJS exports mapping
- Adds explicit `exclude` for test files in `tsconfig.json` (previously skipped by tsup's entry-point filter; now needed since tsc processes all `include` matches)
- Bumps `typescript-eslint` from `8.59.1` to `8.59.2`

## Why not `ignoreDeprecations: "6.0"`?

`baseUrl` will stop functioning entirely in TypeScript 7.0. The suppression flag just kicks the problem down the road. The fix here removes the dependency on `baseUrl` by bypassing the tsup code path that injects it.

## Test plan

- [x] `npm run build` — clean, no deprecation warnings
- [x] `npm test` — 194/194 tests pass
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)