### PR TITLE
refactor: hoist default gamma to module-level constant

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -97,10 +97,11 @@ export const utilA = (teamRatings: TeamRating[]) =>
       teamRatings.filter(([_qMu, _qSigmaSq, _qTeam, qRank]) => iRank === qRank).length
   )
 
-export const gamma = (options: Options): Gamma =>
-  options.gamma ??
-  // default to iSigma / c
-  ((c: number, _k: number, _mu: number, sigmaSq: number, _team: Rating[], _qRank: number) => Math.sqrt(sigmaSq) / c)
+// default to iSigma / c
+const defaultGamma: Gamma = (c: number, _k: number, _mu: number, sigmaSq: number, _team: Rating[], _qRank: number) =>
+  Math.sqrt(sigmaSq) / c
+
+export const gamma = (options: Options): Gamma => options.gamma ?? defaultGamma
 
 export default (options: Options) => ({
   utilC: utilC(options),


### PR DESCRIPTION
## Summary
- Avoids allocating a fresh closure for the default gamma on every `rate()` call when the user does not supply a custom gamma.
- Pure refactor: behavior identical, types unchanged, public surface unchanged.

## Test plan
- [x] `npm test` — 203/203 pass
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)