### PR TITLE
perf: halve work in predictWin, simplify predictDraw

### DIFF
--- a/src/predict-draw.ts
+++ b/src/predict-draw.ts
@@ -1,4 +1,4 @@
-import { flatten, sum, map, addIndex, reduce, head } from 'ramda'
+import { head, map, reduce } from 'ramda'
 import constants from './constants'
 import util, { TeamRating } from './util'
 import { phiMajor, phiMajorInverse } from './statistics'
@@ -8,33 +8,27 @@ const predictDraw = (teams: Team[], options: Options = {}): number => {
   const { teamRating } = util(options)
   const { BETASQ, BETA } = constants(options)
 
-  const totalPlayerCount = flatten(teams).length
+  const totalPlayerCount = reduce((acc: number, t: Team) => acc + t.length, 0, teams)
   const drawProbability = 1 / totalPlayerCount
   const drawMargin = Math.sqrt(totalPlayerCount) * BETA * phiMajorInverse((1 + drawProbability) / 2)
 
   const teamRatings = map<Team, TeamRating>((team) => head<TeamRating>(teamRating([team]))!, teams)
 
-  const pairwiseProbs: number[] = addIndex<TeamRating, number[]>(reduce<TeamRating, number[]>)(
-    (outerAccum: number[], pairA: TeamRating, i: number): number[] => {
-      const [muA, sigmaSqA] = pairA
-      return reduce<TeamRating, number[]>(
-        (innerAccum: number[], pairB: TeamRating): number[] => {
-          const [muB, sigmaSqB] = pairB
-          const sharedDenom = Math.sqrt(totalPlayerCount * BETASQ + sigmaSqA + sigmaSqB)
-          innerAccum.push(
-            phiMajor((drawMargin - muA + muB) / sharedDenom) - phiMajor((muB - muA - drawMargin) / sharedDenom)
-          )
-          return innerAccum
-        },
-        outerAccum,
-        teamRatings.slice(i + 1)
-      )
-    },
-    [],
-    teamRatings
-  )
-
-  return sum(pairwiseProbs) / pairwiseProbs.length
+  // Sum draw-probabilities over every unordered pair (i < j). Single flat
+  // accumulator instead of the previous nested reduce + intermediate array.
+  const n = teamRatings.length
+  let pairCount = 0
+  let total = 0
+  for (let i = 0; i < n; i++) {
+    const [muA, sigmaSqA] = teamRatings[i]
+    for (let j = i + 1; j < n; j++) {
+      const [muB, sigmaSqB] = teamRatings[j]
+      const sharedDenom = Math.sqrt(totalPlayerCount * BETASQ + sigmaSqA + sigmaSqB)
+      total += phiMajor((drawMargin - muA + muB) / sharedDenom) - phiMajor((muB - muA - drawMargin) / sharedDenom)
+      pairCount += 1
+    }
+  }
+  return total / pairCount
 }
 
 export default predictDraw

--- a/src/predict-draw.ts
+++ b/src/predict-draw.ts
@@ -1,4 +1,4 @@
-import { head, map, reduce } from 'ramda'
+import { filter, head, map, range, reduce, xprod } from 'ramda'
 import constants from './constants'
 import util, { TeamRating } from './util'
 import { phiMajor, phiMajorInverse } from './statistics'
@@ -14,21 +14,24 @@ const predictDraw = (teams: Team[], options: Options = {}): number => {
 
   const teamRatings = map<Team, TeamRating>((team) => head<TeamRating>(teamRating([team]))!, teams)
 
-  // Sum draw-probabilities over every unordered pair (i < j). Single flat
-  // accumulator instead of the previous nested reduce + intermediate array.
-  const n = teamRatings.length
-  let pairCount = 0
-  let total = 0
-  for (let i = 0; i < n; i++) {
-    const [muA, sigmaSqA] = teamRatings[i]
-    for (let j = i + 1; j < n; j++) {
+  // Sum draw-probabilities over every unordered pair (i < j) — single flat
+  // reduce over the upper-triangle pair list instead of the previous nested
+  // reduce + intermediate `pairwiseProbs` array.
+  const idx = range(0, teamRatings.length)
+  const pairs = filter(([i, j]: number[]) => i < j, xprod(idx, idx))
+  const { total, count } = reduce(
+    (acc: { total: number; count: number }, [i, j]: number[]) => {
+      const [muA, sigmaSqA] = teamRatings[i]
       const [muB, sigmaSqB] = teamRatings[j]
       const sharedDenom = Math.sqrt(totalPlayerCount * BETASQ + sigmaSqA + sigmaSqB)
-      total += phiMajor((drawMargin - muA + muB) / sharedDenom) - phiMajor((muB - muA - drawMargin) / sharedDenom)
-      pairCount += 1
-    }
-  }
-  return total / pairCount
+      acc.total += phiMajor((drawMargin - muA + muB) / sharedDenom) - phiMajor((muB - muA - drawMargin) / sharedDenom)
+      acc.count += 1
+      return acc
+    },
+    { total: 0, count: 0 },
+    pairs
+  )
+  return total / count
 }
 
 export default predictDraw

--- a/src/predict-win.ts
+++ b/src/predict-win.ts
@@ -1,19 +1,14 @@
-import { reduce } from 'ramda'
+import { chain, map, range, reduce } from 'ramda'
 import constants from './constants'
 import util from './util'
 import { phiMajor } from './statistics'
 import { Options, Team } from './types'
 
-// Lazily yield every unordered pair (i, j) with i < j over [0, n).
-// Used by predictWin to walk the upper triangle without materializing
-// the n²/2 pair list that xprod+filter would build eagerly.
-function* upperTrianglePairs(n: number): Generator<[number, number]> {
-  for (let i = 0; i < n; i += 1) {
-    for (let j = i + 1; j < n; j += 1) {
-      yield [i, j]
-    }
-  }
-}
+// Every unordered pair (i, j) with i < j over [0, n), built tacitly via
+// chain (flatMap). Eager allocation of n²/2 pair tuples; for predictWin's
+// typical n this is negligible.
+const upperTrianglePairs = (n: number): [number, number][] =>
+  chain((i: number) => map((j: number): [number, number] => [i, j], range(i + 1, n)), range(0, n))
 
 const predictWin = (teams: Team[], options: Options = {}) => {
   const { teamRating } = util(options)
@@ -25,8 +20,8 @@ const predictWin = (teams: Team[], options: Options = {}) => {
 
   // phiMajor is symmetric: phiMajor(-x) === 1 - phiMajor(x), and the
   // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A, B). Walk only
-  // the upper-triangle pair stream and add the complementary mass to the
-  // lower index — halves both Math.sqrt and phiMajor calls.
+  // the upper triangle and add the complementary mass to the lower index —
+  // halves both Math.sqrt and phiMajor calls.
   const wins = reduce<[number, number], number[]>(
     (acc, [i, j]) => {
       const [muA, sigmaSqA] = teamRatings[i]
@@ -37,7 +32,7 @@ const predictWin = (teams: Team[], options: Options = {}) => {
       return acc
     },
     new Array(n).fill(0),
-    upperTrianglePairs(n) as unknown as [number, number][]
+    upperTrianglePairs(n)
   )
 
   return wins.map((w) => w / denom)

--- a/src/predict-win.ts
+++ b/src/predict-win.ts
@@ -1,5 +1,5 @@
 import constants from './constants'
-import util, { sum } from './util'
+import util from './util'
 import { phiMajor } from './statistics'
 import { Options, Team } from './types'
 
@@ -11,13 +11,20 @@ const predictWin = (teams: Team[], options: Options = {}) => {
   const n = teams.length
   const denom = (n * (n - 1)) / 2
 
-  return teamRatings.map(
-    ([muA, sigmaSqA], i) =>
-      teamRatings
-        .filter((_, q) => i !== q)
-        .map(([muB, sigmaSqB]) => phiMajor((muA - muB) / Math.sqrt(n * BETASQ + sigmaSqA + sigmaSqB)))
-        .reduce(sum, 0) / denom
-  )
+  // phiMajor is symmetric: phiMajor(-x) === 1 - phiMajor(x), and the
+  // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A,B). Compute
+  // the upper-triangle once and add the complementary mass to the lower.
+  const wins = new Array(n).fill(0) as number[]
+  for (let i = 0; i < n; i++) {
+    const [muA, sigmaSqA] = teamRatings[i]
+    for (let j = i + 1; j < n; j++) {
+      const [muB, sigmaSqB] = teamRatings[j]
+      const p = phiMajor((muA - muB) / Math.sqrt(n * BETASQ + sigmaSqA + sigmaSqB))
+      wins[i] += p
+      wins[j] += 1 - p
+    }
+  }
+  return wins.map((w) => w / denom)
 }
 
 export default predictWin

--- a/src/predict-win.ts
+++ b/src/predict-win.ts
@@ -1,8 +1,19 @@
-import { filter, range, reduce, xprod } from 'ramda'
+import { reduce } from 'ramda'
 import constants from './constants'
 import util from './util'
 import { phiMajor } from './statistics'
 import { Options, Team } from './types'
+
+// Lazily yield every unordered pair (i, j) with i < j over [0, n).
+// Used by predictWin to walk the upper triangle without materializing
+// the n²/2 pair list that xprod+filter would build eagerly.
+function* upperTrianglePairs(n: number): Generator<[number, number]> {
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      yield [i, j]
+    }
+  }
+}
 
 const predictWin = (teams: Team[], options: Options = {}) => {
   const { teamRating } = util(options)
@@ -13,12 +24,10 @@ const predictWin = (teams: Team[], options: Options = {}) => {
   const denom = (n * (n - 1)) / 2
 
   // phiMajor is symmetric: phiMajor(-x) === 1 - phiMajor(x), and the
-  // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A,B). Walk only
-  // the upper-triangle pair list and add the complementary mass to the lower
-  // index — halves both Math.sqrt and phiMajor calls.
-  const idx = range(0, n)
-  const pairs = filter(([i, j]: number[]) => i < j, xprod(idx, idx))
-  const wins = reduce<number[], number[]>(
+  // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A, B). Walk only
+  // the upper-triangle pair stream and add the complementary mass to the
+  // lower index — halves both Math.sqrt and phiMajor calls.
+  const wins = reduce<[number, number], number[]>(
     (acc, [i, j]) => {
       const [muA, sigmaSqA] = teamRatings[i]
       const [muB, sigmaSqB] = teamRatings[j]
@@ -28,7 +37,7 @@ const predictWin = (teams: Team[], options: Options = {}) => {
       return acc
     },
     new Array(n).fill(0),
-    pairs
+    upperTrianglePairs(n) as unknown as [number, number][]
   )
 
   return wins.map((w) => w / denom)

--- a/src/predict-win.ts
+++ b/src/predict-win.ts
@@ -1,3 +1,4 @@
+import { filter, range, reduce, xprod } from 'ramda'
 import constants from './constants'
 import util from './util'
 import { phiMajor } from './statistics'
@@ -12,18 +13,24 @@ const predictWin = (teams: Team[], options: Options = {}) => {
   const denom = (n * (n - 1)) / 2
 
   // phiMajor is symmetric: phiMajor(-x) === 1 - phiMajor(x), and the
-  // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A,B). Compute
-  // the upper-triangle once and add the complementary mass to the lower.
-  const wins = new Array(n).fill(0) as number[]
-  for (let i = 0; i < n; i++) {
-    const [muA, sigmaSqA] = teamRatings[i]
-    for (let j = i + 1; j < n; j++) {
+  // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A,B). Walk only
+  // the upper-triangle pair list and add the complementary mass to the lower
+  // index — halves both Math.sqrt and phiMajor calls.
+  const idx = range(0, n)
+  const pairs = filter(([i, j]: number[]) => i < j, xprod(idx, idx))
+  const wins = reduce<number[], number[]>(
+    (acc, [i, j]) => {
+      const [muA, sigmaSqA] = teamRatings[i]
       const [muB, sigmaSqB] = teamRatings[j]
       const p = phiMajor((muA - muB) / Math.sqrt(n * BETASQ + sigmaSqA + sigmaSqB))
-      wins[i] += p
-      wins[j] += 1 - p
-    }
-  }
+      acc[i] += p
+      acc[j] += 1 - p
+      return acc
+    },
+    new Array(n).fill(0),
+    pairs
+  )
+
   return wins.map((w) => w / denom)
 }
 

--- a/src/predict-win.ts
+++ b/src/predict-win.ts
@@ -1,14 +1,19 @@
-import { chain, map, range, reduce } from 'ramda'
+import { reduce } from 'ramda'
 import constants from './constants'
 import util from './util'
 import { phiMajor } from './statistics'
 import { Options, Team } from './types'
 
-// Every unordered pair (i, j) with i < j over [0, n), built tacitly via
-// chain (flatMap). Eager allocation of n²/2 pair tuples; for predictWin's
-// typical n this is negligible.
-const upperTrianglePairs = (n: number): [number, number][] =>
-  chain((i: number) => map((j: number): [number, number] => [i, j], range(i + 1, n)), range(0, n))
+// Lazily yield every unordered pair (i, j) with i < j over [0, n).
+// Used by predictWin to walk the upper triangle without materializing
+// the n²/2 pair list that xprod+filter would build eagerly.
+function* upperTrianglePairs(n: number): Generator<[number, number]> {
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      yield [i, j]
+    }
+  }
+}
 
 const predictWin = (teams: Team[], options: Options = {}) => {
   const { teamRating } = util(options)
@@ -20,8 +25,8 @@ const predictWin = (teams: Team[], options: Options = {}) => {
 
   // phiMajor is symmetric: phiMajor(-x) === 1 - phiMajor(x), and the
   // sqrt(n·β² + σ²_A + σ²_B) denominator is symmetric in (A, B). Walk only
-  // the upper triangle and add the complementary mass to the lower index —
-  // halves both Math.sqrt and phiMajor calls.
+  // the upper-triangle pair stream and add the complementary mass to the
+  // lower index — halves both Math.sqrt and phiMajor calls.
   const wins = reduce<[number, number], number[]>(
     (acc, [i, j]) => {
       const [muA, sigmaSqA] = teamRatings[i]
@@ -32,7 +37,7 @@ const predictWin = (teams: Team[], options: Options = {}) => {
       return acc
     },
     new Array(n).fill(0),
-    upperTrianglePairs(n)
+    upperTrianglePairs(n) as unknown as [number, number][]
   )
 
   return wins.map((w) => w / denom)


### PR DESCRIPTION
## Summary
- `predictWin` now walks only the upper triangle of the pair matrix, exploiting the symmetry of `phiMajor` and the shared denominator. Halves both `Math.sqrt` and `phiMajor` calls.
- `predictDraw` drops `flatten` (replaced by a `reduce` summing team lengths) and replaces the nested `addIndex(reduce)` pyramid with a flat accumulator — no intermediate `pairwiseProbs` array.
- Behavior identical; all 203 tests pass.

## Test plan
- [x] `npm test` — 203/203 pass
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)