### PR TITLE
refactor: extract marginAmp/marginFactor helpers from rate()

### DIFF
--- a/src/__tests__/margin-helpers.test.ts
+++ b/src/__tests__/margin-helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '#test-helpers'
+import { marginAmp, marginFactor } from '../margin'
+
+describe('marginAmp', () => {
+  it('returns 0 when the score difference is within the margin', () => {
+    expect.assertions(2)
+    expect(marginAmp(0, 5)).toBe(0)
+    expect(marginAmp(5, 5)).toBe(0)
+  })
+
+  it('grows logarithmically with the excess over the margin', () => {
+    expect.assertions(1)
+    expect(marginAmp(15, 5)).toBeCloseTo(Math.log1p(10), 12)
+  })
+})
+
+describe('marginFactor', () => {
+  it('returns 1 for a single team (degenerate case)', () => {
+    expect.assertions(1)
+    expect(marginFactor([10], 0, 5)).toBe(1)
+  })
+
+  it('returns 1 when every opponent is within the margin', () => {
+    expect.assertions(1)
+    expect(marginFactor([10, 12, 8], 0, 5)).toBe(1)
+  })
+
+  it('averages the per-opponent amplification', () => {
+    expect.assertions(1)
+    // i = 0, score 20, opponents 10 and 8, margin 5
+    // amps: log1p(20-10-5)=log1p(5), log1p(20-8-5)=log1p(7)
+    // factor = 1 + (log1p(5) + log1p(7)) / 2
+    const expected = 1 + (Math.log1p(5) + Math.log1p(7)) / 2
+    expect(marginFactor([20, 10, 8], 0, 5)).toBeCloseTo(expected, 12)
+  })
+})

--- a/src/margin.ts
+++ b/src/margin.ts
@@ -1,0 +1,22 @@
+/**
+ * Amplification contribution from a single score difference.
+ *
+ * Returns 0 when the absolute score gap is within the margin threshold;
+ * otherwise grows logarithmically with the excess. log1p is used so that
+ * large blowouts don't produce runaway factors.
+ */
+export const marginAmp = (absDiff: number, margin: number): number => Math.log1p(Math.max(0, absDiff - margin))
+
+/**
+ * Per-team amplification factor used by `rate()` when both `score` and
+ * `margin` are supplied. Averages `marginAmp` across all opponents and
+ * adds 1 so that an in-margin (no-amp) result leaves rating updates
+ * unchanged.
+ */
+export const marginFactor = (scores: number[], i: number, margin: number): number => {
+  const n = scores.length
+  if (n <= 1) return 1
+  const si = scores[i]
+  const sum = scores.reduce((acc, sj, j) => (j === i ? acc : acc + marginAmp(Math.abs(si - sj), margin)), 0)
+  return 1 + sum / (n - 1)
+}

--- a/src/rate.ts
+++ b/src/rate.ts
@@ -3,6 +3,7 @@ import { unwind } from 'sort-unwind'
 
 import { Rating, Options, Team } from './types'
 import constants from './constants'
+import { marginFactor } from './margin'
 import { plackettLuce } from './models'
 
 const rate = (teams: Team[], options: Options = {}): Team[] => {
@@ -37,18 +38,12 @@ const rate = (teams: Team[], options: Options = {}): Team[] => {
   if (options.score && options.margin) {
     const scores = options.score
     const margin = options.margin
-    const n = teams.length
     reorderedTeams = reorderedTeams.map((team: Rating[], i: number) => {
-      const factor =
-        1 +
-        scores.reduce((acc, sj, j) => {
-          if (j === i) return acc
-          return acc + Math.log1p(Math.max(0, Math.abs(scores[i] - sj) - margin)) / (n - 1)
-        }, 0)
-      return team.map((p: Rating, k: number) => ({
-        mu: processedTeams[i][k].mu + factor * (p.mu - processedTeams[i][k].mu),
-        sigma: p.sigma,
-      }))
+      const factor = marginFactor(scores, i, margin)
+      return team.map((p: Rating, k: number) => {
+        const priorMu = processedTeams[i][k].mu
+        return { mu: priorMu + factor * (p.mu - priorMu), sigma: p.sigma }
+      })
     })
   }
 


### PR DESCRIPTION
## Summary
- Extract the `Math.log1p(Math.max(0, ...))` amplification math into `marginAmp`, and the per-team averaging into `marginFactor`, in a new `src/margin.ts` module.
- Bind `processedTeams[i][k].mu` once per player inside the inner map (was referenced four times).
- Adds 5 focused unit tests covering edge cases (degenerate single team, all-within-margin, mixed). The existing integrated margin test continues to cover end-to-end behavior.

## Test plan
- [x] `npm test` — 208/208 pass (5 new)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)