### PR TITLE
refactor(models): mutate {omega,delta} accumulator inside reduce

### DIFF
--- a/src/models/bradley-terry-full.ts
+++ b/src/models/bradley-terry-full.ts
@@ -9,21 +9,20 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
 
   return teamRatings.map((iTeamRating, i) => {
     const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating
-    const [iOmega, iDelta] = teamRatings
+    const { omega: iOmega, delta: iDelta } = teamRatings
       .filter((_, q) => q !== i)
       .reduce(
-        ([omega, delta], [qMu, qSigmaSq, _qTeam, qRank]) => {
+        (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const piq = 1 / (1 + Math.exp((qMu - iMu) / ciq))
           const sigSqToCiq = iSigmaSq / ciq
           const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
-          return [
-            omega + sigSqToCiq * (score(qRank, iRank) - piq),
-            delta + ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq),
-          ]
+          acc.omega += sigSqToCiq * (score(qRank, iRank) - piq)
+          acc.delta += ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq)
+          return acc
         },
-        [0, 0]
+        { omega: 0, delta: 0 }
       )
 
     return iTeam.map(({ mu, sigma }) => {

--- a/src/models/bradley-terry-part.ts
+++ b/src/models/bradley-terry-part.ts
@@ -12,19 +12,18 @@ const model: Model = (game: Rating[][], options = {}) => {
 
   return zip(teamRatings, adjacentTeams).map(([iTeamRating, iAdjacents]) => {
     const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating
-    const [iOmega, iDelta] = iAdjacents.reduce(
-      ([omega, delta], [qMu, qSigmaSq, _qTeam, qRank]) => {
+    const { omega: iOmega, delta: iDelta } = iAdjacents.reduce(
+      (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
         const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
         const piq = 1 / (1 + Math.exp((qMu - iMu) / ciq))
         const sigSqToCiq = iSigmaSq / ciq
         const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
-        return [
-          omega + sigSqToCiq * (score(qRank, iRank) - piq),
-          delta + ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq),
-        ]
+        acc.omega += sigSqToCiq * (score(qRank, iRank) - piq)
+        acc.delta += ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq)
+        return acc
       },
-      [0, 0]
+      { omega: 0, delta: 0 }
     )
 
     return iTeam.map(({ mu, sigma }) => {

--- a/src/models/plackett-luce.ts
+++ b/src/models/plackett-luce.ts
@@ -13,13 +13,15 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
   return teamRatings.map((iTeamRating, i) => {
     const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating
     const iMuOverCe = Math.exp(iMu / c)
-    const [omegaSum, deltaSum] = teamRatings.reduce(
-      ([omega, delta], [_qMu, _qSigmaSq, _qTeam, qRank], q) => {
-        if (qRank > iRank) return [omega, delta]
+    const { omega: omegaSum, delta: deltaSum } = teamRatings.reduce(
+      (acc, [_qMu, _qSigmaSq, _qTeam, qRank], q) => {
+        if (qRank > iRank) return acc
         const quotient = iMuOverCe / sumQ[q]
-        return [omega + (i === q ? 1 - quotient : -quotient) / a[q], delta + (quotient * (1 - quotient)) / a[q]]
+        acc.omega += (i === q ? 1 - quotient : -quotient) / a[q]
+        acc.delta += (quotient * (1 - quotient)) / a[q]
+        return acc
       },
-      [0, 0]
+      { omega: 0, delta: 0 }
     )
 
     const iGamma = gamma(c, teamRatings.length, ...iTeamRating)

--- a/src/models/thurstone-mosteller-full.ts
+++ b/src/models/thurstone-mosteller-full.ts
@@ -10,29 +10,27 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
 
   return teamRatings.map((iTeamRating, i) => {
     const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating
-    const [iOmega, iDelta] = teamRatings
+    const { omega: iOmega, delta: iDelta } = teamRatings
       .filter((_, q) => i !== q)
       .reduce(
-        ([omega, delta], [qMu, qSigmaSq, _qTeam, qRank]) => {
+        (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const deltaMu = (iMu - qMu) / ciq
           const sigSqToCiq = iSigmaSq / ciq
           const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
           if (qRank === iRank) {
-            return [
-              omega + sigSqToCiq * vt(deltaMu, EPSILON / ciq),
-              delta + ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq),
-            ]
+            acc.omega += sigSqToCiq * vt(deltaMu, EPSILON / ciq)
+            acc.delta += ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq)
+            return acc
           }
 
           const sign = qRank > iRank ? 1 : -1
-          return [
-            omega + sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq),
-            delta + ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq),
-          ]
+          acc.omega += sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq)
+          acc.delta += ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq)
+          return acc
         },
-        [0, 0]
+        { omega: 0, delta: 0 }
       )
 
     return iTeam.map(({ mu, sigma }) => {

--- a/src/models/thurstone-mosteller-part.ts
+++ b/src/models/thurstone-mosteller-part.ts
@@ -12,27 +12,25 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
 
   return zip(teamRatings, adjacentTeams).map(([iTeamRating, iAdjacents]) => {
     const [iMu, iSigmaSq, iTeam, iRank] = iTeamRating
-    const [iOmega, iDelta] = iAdjacents.reduce(
-      ([omega, delta], [qMu, qSigmaSq, _qTeam, qRank]) => {
+    const { omega: iOmega, delta: iDelta } = iAdjacents.reduce(
+      (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
         const ciq = 2 * Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
         const deltaMu = (iMu - qMu) / ciq
         const sigSqToCiq = iSigmaSq / ciq
         const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
         if (qRank === iRank) {
-          return [
-            omega + sigSqToCiq * vt(deltaMu, EPSILON / ciq),
-            delta + ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq),
-          ]
+          acc.omega += sigSqToCiq * vt(deltaMu, EPSILON / ciq)
+          acc.delta += ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq)
+          return acc
         }
 
         const sign = qRank > iRank ? 1 : -1
-        return [
-          omega + sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq),
-          delta + ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq),
-        ]
+        acc.omega += sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq)
+        acc.delta += ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq)
+        return acc
       },
-      [0, 0]
+      { omega: 0, delta: 0 }
     )
 
     return iTeam.map(({ mu, sigma }) => {


### PR DESCRIPTION
## Summary

Every inner `reduce` in the five rating models was returning a fresh `[omega, delta]` tuple on each step, allocating a new 2-element array per pairwise team interaction in the hot path.

This switches each model to a named object accumulator (`{ omega, delta }`) that is mutated and returned by reference inside `.reduce`. The functional reduce shape is preserved; only the per-step allocation is dropped.

- `bradley-terry-full.ts`
- `bradley-terry-part.ts`
- `thurstone-mosteller-full.ts`
- `thurstone-mosteller-part.ts`
- `plackett-luce.ts`

Net: 41 lines removed, 37 added. The math also reads a bit closer to the paper now (`acc.omega += ...; acc.delta += ...` rather than reconstructing the tuple).

## Test plan

- [x] `npm test` — 203/203 pass
- [x] `npm run lint` — clean
- [ ] Confirm parity tests still match openskill.py reference vectors (covered by existing `parity-*.test.ts` suites)


---
_Generated by [Claude Code](https://claude.ai/code/session_0125SrW5WBzG2YejyefypEvW)_