### PR TITLE
feat!: remove deprecated preventSigmaIncrease option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ changes were required:
 - The standard-normal CDF/PDF in `src/statistics.ts` are now computed via
   `erf` using Python's `NormalDist` formulas (`0.5 * (1 + erf(z / √2))`,
   `exp(z²/-2) / √(2π)`). This should only affect the Thurstone-Mosteller model.
+- The long-deprecated `preventSigmaIncrease` option has been removed. Use
+  `limitSigma` instead.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openskill",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Weng-Lin Bayesian approximation method for online skill-ranking.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openskill",
-  "version": "5.0.0",
+  "version": "4.1.1",
   "description": "Weng-Lin Bayesian approximation method for online skill-ranking.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/__tests__/rate.test.ts
+++ b/src/__tests__/rate.test.ts
@@ -42,12 +42,12 @@ describe('rate', () => {
     ])
   })
 
-  it('rate accepts and runs a placket-luce model with tau and prevent_sigma_increase', () => {
+  it('rate accepts and runs a placket-luce model with tau and limitSigma', () => {
     expect.assertions(2)
     const a1 = rating({ mu: 6.672, sigma: 0.0001 })
     const b1 = rating({ mu: 29.182, sigma: 4.782 })
 
-    const [[a2], [b2]] = rate([[a1], [b1]], { tau: 0.01, preventSigmaIncrease: true })
+    const [[a2], [b2]] = rate([[a1], [b1]], { tau: 0.01, limitSigma: true })
 
     expect(a2.sigma).toBeLessThanOrEqual(a1.sigma)
     expect([[a2], [b2]]).toStrictEqual([
@@ -97,7 +97,7 @@ describe('rate', () => {
     ])
   })
 
-  it('rate accepts and runs a placket-luce model by default for teams with tau and prevent_sigma_increase', () => {
+  it('rate accepts and runs a placket-luce model by default for teams with tau and limitSigma', () => {
     const a1 = rating({ mu: 9.182, sigma: 0.0001 })
     const b1 = rating({ mu: 27.174, sigma: 4.922 })
     const c1 = rating({ mu: 16.672, sigma: 6.217 })
@@ -108,7 +108,7 @@ describe('rate', () => {
         [a1, b1],
         [c1, d1],
       ],
-      { tau: 0.01, preventSigmaIncrease: true }
+      { tau: 0.01, limitSigma: true }
     )
 
     expect(a2.sigma).toBeLessThanOrEqual(a1.sigma)
@@ -314,21 +314,6 @@ describe('rate', () => {
     const [[winner], [loser]] = rate([[a], [b]], {
       tau: 0.3,
       limitSigma: true,
-    })
-
-    expect([winner, loser]).toStrictEqual([
-      { mu: 40.00032667136128, sigma: 3 },
-      { mu: -20.000326671361275, sigma: 3 },
-    ])
-  })
-
-  it('prevents sigma rising with old syntax', () => {
-    expect.assertions(1)
-    const a = rating({ mu: 40, sigma: 3 })
-    const b = rating({ mu: -20, sigma: 3 })
-    const [[winner], [loser]] = rate([[a], [b]], {
-      tau: 0.3,
-      preventSigmaIncrease: true,
     })
 
     expect([winner, loser]).toStrictEqual([

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,8 @@ import { Options } from './types'
 
 const builder = (options: Options) => {
   // i'd love to know of a better way to do this
-  const { z = 3, mu = 25, preventSigmaIncrease = false, epsilon = 0.1, alpha = 1, target = 0 } = options
-  const { tau = 25 / 300, sigma = 25 / 3, beta = 25 / 6, limitSigma = preventSigmaIncrease } = options
+  const { z = 3, mu = 25, epsilon = 0.1, alpha = 1, target = 0 } = options
+  const { tau = 25 / 300, sigma = 25 / 3, beta = 25 / 6, limitSigma = false } = options
   const { balance = false, kappa = 0.0001 } = options
   const betaSq = beta ** 2
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,6 @@ export type Options = {
   margin?: number
   alpha?: number
   target?: number
-  preventSigmaIncrease?: boolean // deprecated, use limitSigma, this will go away someday
   limitSigma?: boolean
   balance?: boolean
   kappa?: number


### PR DESCRIPTION
## Summary

- Removes the long-deprecated `preventSigmaIncrease` option (replaced by `limitSigma`). The old name was kept as an alias with a `// this will go away someday` note since before this repo's visible git history — v5 is the right time to drop it.
- Updates the three remaining test usages to `limitSigma`, and removes one test that was an exact duplicate of the equivalent `limitSigma` test.

## Test plan

- [x] `npm test` — all 207 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01719Q7A1UTo7VoLBS8SMLWs)_