### PR TITLE
refactor(models): rename sigSqToCiq to qEta to match paper notation

### DIFF
--- a/src/models/bradley-terry-full.ts
+++ b/src/models/bradley-terry-full.ts
@@ -15,11 +15,11 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
         (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const piq = 1 / (1 + Math.exp((qMu - iMu) / ciq))
-          const sigSqToCiq = iSigmaSq / ciq
+          const qEta = iSigmaSq / ciq
           const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
-          acc.omega += sigSqToCiq * (score(qRank, iRank) - piq)
-          acc.delta += ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq)
+          acc.omega += qEta * (score(qRank, iRank) - piq)
+          acc.delta += ((iGamma * qEta) / ciq) * piq * (1 - piq)
           return acc
         },
         { omega: 0, delta: 0 }

--- a/src/models/bradley-terry-part.ts
+++ b/src/models/bradley-terry-part.ts
@@ -16,11 +16,11 @@ const model: Model = (game: Rating[][], options = {}) => {
       (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
         const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
         const piq = 1 / (1 + Math.exp((qMu - iMu) / ciq))
-        const sigSqToCiq = iSigmaSq / ciq
+        const qEta = iSigmaSq / ciq
         const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
-        acc.omega += sigSqToCiq * (score(qRank, iRank) - piq)
-        acc.delta += ((iGamma * sigSqToCiq) / ciq) * piq * (1 - piq)
+        acc.omega += qEta * (score(qRank, iRank) - piq)
+        acc.delta += ((iGamma * qEta) / ciq) * piq * (1 - piq)
         return acc
       },
       { omega: 0, delta: 0 }

--- a/src/models/thurstone-mosteller-full.ts
+++ b/src/models/thurstone-mosteller-full.ts
@@ -16,18 +16,18 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
         (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
           const ciq = Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
           const deltaMu = (iMu - qMu) / ciq
-          const sigSqToCiq = iSigmaSq / ciq
+          const qEta = iSigmaSq / ciq
           const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
           if (qRank === iRank) {
-            acc.omega += sigSqToCiq * vt(deltaMu, EPSILON / ciq)
-            acc.delta += ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq)
+            acc.omega += qEta * vt(deltaMu, EPSILON / ciq)
+            acc.delta += ((iGamma * qEta) / ciq) * wt(deltaMu, EPSILON / ciq)
             return acc
           }
 
           const sign = qRank > iRank ? 1 : -1
-          acc.omega += sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq)
-          acc.delta += ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq)
+          acc.omega += sign * qEta * v(sign * deltaMu, EPSILON / ciq)
+          acc.delta += ((iGamma * qEta) / ciq) * w(sign * deltaMu, EPSILON / ciq)
           return acc
         },
         { omega: 0, delta: 0 }

--- a/src/models/thurstone-mosteller-part.ts
+++ b/src/models/thurstone-mosteller-part.ts
@@ -16,18 +16,18 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
       (acc, [qMu, qSigmaSq, _qTeam, qRank]) => {
         const ciq = 2 * Math.sqrt(iSigmaSq + qSigmaSq + TWOBETASQ)
         const deltaMu = (iMu - qMu) / ciq
-        const sigSqToCiq = iSigmaSq / ciq
+        const qEta = iSigmaSq / ciq
         const iGamma = gamma(ciq, teamRatings.length, ...iTeamRating)
 
         if (qRank === iRank) {
-          acc.omega += sigSqToCiq * vt(deltaMu, EPSILON / ciq)
-          acc.delta += ((iGamma * sigSqToCiq) / ciq) * wt(deltaMu, EPSILON / ciq)
+          acc.omega += qEta * vt(deltaMu, EPSILON / ciq)
+          acc.delta += ((iGamma * qEta) / ciq) * wt(deltaMu, EPSILON / ciq)
           return acc
         }
 
         const sign = qRank > iRank ? 1 : -1
-        acc.omega += sign * sigSqToCiq * v(sign * deltaMu, EPSILON / ciq)
-        acc.delta += ((iGamma * sigSqToCiq) / ciq) * w(sign * deltaMu, EPSILON / ciq)
+        acc.omega += sign * qEta * v(sign * deltaMu, EPSILON / ciq)
+        acc.delta += ((iGamma * qEta) / ciq) * w(sign * deltaMu, EPSILON / ciq)
         return acc
       },
       { omega: 0, delta: 0 }


### PR DESCRIPTION
## Summary
- Renames the local `sigSqToCiq` variable to `qEta` across the Bradley-Terry and Thurstone-Mosteller models so it matches η_q from Weng & Lin (2011) §3.1.1.
- Pure rename, no behaviour change. All 208 tests pass.

Addresses #203 (the specific example called out in the issue body).

## Test plan
- [x] `npm test` — all 208 tests pass
- [ ] Confirm naming is preferred (`qEta` vs e.g. `etaQ`) before merging

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZBQL2LQ2s4bNiWQnTSneu)_