### PR TITLE
chore: bump version to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openskill",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Weng-Lin Bayesian approximation method for online skill-ranking.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Bumps `package.json` from `4.1.1` to `5.0.0`. The README's "Breaking Changes in v5.0.0" section (added with #971) already documents the behavioral break — this PR formally ships the version.

Merge this after #989.


---
_Generated by [Claude Code](https://claude.ai/code/session_01719Q7A1UTo7VoLBS8SMLWs)_