### PR TITLE
fix: treat zero-indexed equal ranks as draws (#262)

### DIFF
--- a/src/__tests__/rate.test.ts
+++ b/src/__tests__/rate.test.ts
@@ -233,6 +233,28 @@ describe('rate', () => {
     ])
   })
 
+  it('treats equal zero ranks as a draw (1v1)', () => {
+    expect.assertions(1)
+    const [[a], [b]] = rate([[rating()], [rating()]], {
+      rank: [0, 0],
+    })
+    expect([a, b]).toStrictEqual([
+      { mu: 25, sigma: 8.06590141354368 },
+      { mu: 25, sigma: 8.06590141354368 },
+    ])
+  })
+
+  it('treats equal zero scores as a draw (1v1)', () => {
+    expect.assertions(1)
+    const [[a], [b]] = rate([[rating()], [rating()]], {
+      score: [0, 0],
+    })
+    expect([a, b]).toStrictEqual([
+      { mu: 25, sigma: 8.06590141354368 },
+      { mu: 25, sigma: 8.06590141354368 },
+    ])
+  })
+
   it('fixes orders of ties', () => {
     expect.assertions(1)
     const [[w2], [x2], [y2], [z2]] = rate([[w1], [x1], [y1], [z1]], {

--- a/src/__tests__/util/rankings.test.ts
+++ b/src/__tests__/util/rankings.test.ts
@@ -33,6 +33,18 @@ describe('util#rankings', () => {
     expect.assertions(1)
     expect(rankings([a, b, c, d], [1, 2, 3, 4])).toStrictEqual([0, 1, 2, 3])
   })
+  it('ranks given zero-indexed incremental', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], [0, 1, 2, 3])).toStrictEqual([0, 1, 2, 3])
+  })
+  it('treats equal zero ranks as a draw', () => {
+    expect.assertions(1)
+    expect(rankings([a, b], [0, 0])).toStrictEqual([0, 0])
+  })
+  it('ranks zero-indexed with ties in start', () => {
+    expect.assertions(1)
+    expect(rankings([a, b, c, d], [0, 0, 2, 3])).toStrictEqual([0, 0, 2, 3])
+  })
   it('ranks with ties in start', () => {
     expect.assertions(1)
     expect(rankings([a, b, c, d], [1, 1, 3, 4])).toStrictEqual([0, 0, 2, 3])

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,7 @@ export const score = (q: number, i: number) => {
 }
 
 export const rankings = (teams: Team[], rank: number[] = []) => {
-  const teamScores = teams.map((_, i) => rank[i] || i)
+  const teamScores = teams.map((_, i) => rank[i] ?? i)
   const outRank = new Array(teams.length)
 
   let s = 0


### PR DESCRIPTION
## Summary

Fixes #262 — passing zero-indexed equal ranks (e.g. `rank: [0, 0]`) did not produce a draw.

The `rankings` helper in `src/util.ts` used `rank[i] || i`. Because `0` is falsy, any rank of `0` fell back to the team's index, so a draw like `rank: [0, 0]` was silently rewritten to `[0, 1]` — a win/loss. The same bug affected equal scores, since `score` is mapped to negated values where ties land on `0`.

The collaborators in the issue confirmed this was a bug and suggested users work around it by starting ranks at `1`. This switches the fallback to nullish coalescing (`rank[i] ?? i`) so only genuinely missing ranks fall back to the index, while explicit `0` ranks are respected.

### Before
```js
rate([[rating()], [rating()]], { rank: [0, 0] })
// [[{ mu: 27.64, ... }], [{ mu: 22.36, ... }]]  ❌ win/loss
```

### After
```js
rate([[rating()], [rating()]], { rank: [0, 0] })
// [[{ mu: 25, ... }], [{ mu: 25, ... }]]  ✅ draw
```

## Changes
- `src/util.ts`: `rank[i] || i` → `rank[i] ?? i` in `rankings`.
- `src/__tests__/util/rankings.test.ts`: added cases for zero-indexed ranks and zero-rank ties.
- `src/__tests__/rate.test.ts`: added 1v1 draw tests for both `rank: [0, 0]` and `score: [0, 0]`.

## Testing
All 212 tests pass (`npm test`).

https://claude.ai/code/session_01WY8h6aYpiYfRobypqjTHgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY8h6aYpiYfRobypqjTHgB)_