### PR TITLE
ci: auto-enable GitHub Pages in docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,10 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          # Enable GitHub Pages (with the "GitHub Actions" source) automatically
+          # if it isn't already, so the deploy job has a Pages site to publish to.
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Problem

The `Deploy Docs` workflow [failed on `main`](https://github.com/philihp/openskill.js/actions/runs/26805502407) after #1000 merged. The `build` job succeeded, but the `deploy` job failed within 2 seconds — the signature of `actions/deploy-pages` having no Pages site to publish to because **GitHub Pages was never enabled** with the "GitHub Actions" source.

## Fix

Set `enablement: true` on the `actions/configure-pages@v5` step. This provisions the Pages site (with the GitHub Actions build source) directly from the workflow using the existing `pages: write` permission, so no manual settings change is required. Re-running the workflow after this merges should publish to https://philihp.github.io/openskill.js/.

> [!NOTE]
> If the repository's org/account policy disables Pages entirely, `enablement: true` can't override that — in that case Pages must be turned on once under **Settings → Pages**. But for a standard repo this removes the manual step.

https://claude.ai/code/session_01TwzYShuwDzEkWB8R93DjMn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwzYShuwDzEkWB8R93DjMn)_