### PR TITLE
Preserve per-team rating shape in rate() return type

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v6
       - run: npm install
       - run: npm run lint
+      - run: npm run typecheck
 
   tests:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "tsup && tsc --declaration --emitDeclarationOnly --rootDir src --outDir dist && for f in $(find dist -name '*.d.ts' ! -name '*.d.cts'); do cp \"$f\" \"${f%.d.ts}.d.cts\"; done",
     "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "prepare": "husky && npm run build",
     "release": "np",
     "test": "node --import tsx --test",

--- a/src/__tests__/rate-types.test-d.ts
+++ b/src/__tests__/rate-types.test-d.ts
@@ -67,3 +67,28 @@ const mixed = rate(
   { score: [2, 1], margin: 5 }
 )
 type _mixed = Expect<Equal<typeof mixed, [[Rating, Rating, Rating], [Rating, Rating]]>>
+
+// The guarantee holds for ANY number of teams and ANY number of ratings per
+// team -- nothing about the typing is specialized to a particular size.
+
+// One team, one rating.
+const solo = rate([[a]])
+type _solo = Expect<Equal<typeof solo, [[Rating]]>>
+
+// Ten single-rating teams (classic free-for-all).
+const ffa = rate([[a], [b], [c], [d], [e], [f], [g], [a], [b], [c]])
+type _ffa = Expect<
+  Equal<
+    typeof ffa,
+    [[Rating], [Rating], [Rating], [Rating], [Rating], [Rating], [Rating], [Rating], [Rating], [Rating]]
+  >
+>
+
+// Six teams of wildly different sizes: 2, 1, 3, 1, 4, 2.
+const ragged = rate([[a, b], [c], [d, e, f], [g], [a, b, c, d], [e, f]])
+type _ragged = Expect<
+  Equal<
+    typeof ragged,
+    [[Rating, Rating], [Rating], [Rating, Rating, Rating], [Rating], [Rating, Rating, Rating, Rating], [Rating, Rating]]
+  >
+>

--- a/src/__tests__/rate-types.test-d.ts
+++ b/src/__tests__/rate-types.test-d.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Type-level checks for rate()'s shape-preserving signature.
+// These are compile-time only assertions; `npm run build` (tsc) fails if any
+// of them break. There is nothing to execute at runtime.
+import { rate, rating, Rating } from '../index'
+
+type Expect<T extends true> = T
+// Mutual-assignability equality: distinguishes tuple lengths and tuple-vs-array,
+// which is exactly what the rate() typing guarantees, without the brittleness of
+// the stricter `(<T>() => ...)` identity check against deferred mapped types.
+type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+
+const a = rating()
+const b = rating()
+const c = rating()
+const d = rating()
+const e = rating()
+const f = rating()
+const g = rating()
+
+// Three teams with 5, 4 and 7 ratings -> same three-team, 5/4/7 shape out.
+const out = rate([
+  [a, b, c, d, e],
+  [a, b, c, d],
+  [a, b, c, d, e, f, g],
+])
+
+type Out = typeof out
+type _preservesShape = Expect<
+  Equal<
+    Out,
+    [
+      [Rating, Rating, Rating, Rating, Rating],
+      [Rating, Rating, Rating, Rating],
+      [Rating, Rating, Rating, Rating, Rating, Rating, Rating],
+    ]
+  >
+>
+
+// The result is a fixed-length tuple per team, not a Rating[] -- indexing past
+// the known length is a compile error.
+const [team0, team1, team2] = out
+const [r0, r1, r2, r3, r4] = team0
+// @ts-expect-error team0 only has 5 ratings, there is no 6th
+const six = team0[5]
+// @ts-expect-error there is no 4th team
+const team3 = out[3]
+
+// A plain Rating[][] (non-literal) still works and maps back to Rating[][].
+const dynamic: Rating[][] = [
+  [a, b],
+  [c, d],
+]
+const dynamicOut = rate(dynamic)
+type _dynamic = Expect<Equal<typeof dynamicOut, Rating[][]>>
+
+// Options are still accepted and do not change the shape preservation.
+const withOpts = rate([[a], [b]], { tau: 0.3, limitSigma: true })
+type _withOpts = Expect<Equal<typeof withOpts, [[Rating], [Rating]]>>
+
+// Asymmetric teams with options.
+const mixed = rate(
+  [
+    [a, b, c],
+    [d, e],
+  ],
+  { score: [2, 1], margin: 5 }
+)
+type _mixed = Expect<Equal<typeof mixed, [[Rating, Rating, Rating], [Rating, Rating]]>>

--- a/src/rate.ts
+++ b/src/rate.ts
@@ -58,8 +58,6 @@ const rate = <const T extends Teams>(teams: T, options: Options = {}): RateResul
     )
   }
 
-  // the runtime always returns teams matching the input shape; the cast bridges
-  // the dynamically built Team[] to the statically inferred RateResult<T>.
   return reorderedTeams as RateResult<T>
 }
 

--- a/src/rate.ts
+++ b/src/rate.ts
@@ -1,12 +1,12 @@
 import { sortBy, identity, range } from 'ramda'
 import { unwind } from 'sort-unwind'
 
-import { Rating, Options, Team } from './types'
+import { Rating, Options, Teams, RateResult } from './types'
 import constants from './constants'
 import { marginFactor } from './margin'
 import { plackettLuce } from './models'
 
-const rate = (teams: Team[], options: Options = {}): Team[] => {
+const rate = <const T extends Teams>(teams: T, options: Options = {}): RateResult<T> => {
   const { LIMIT_SIGMA, TAU } = constants(options)
   const { model = plackettLuce } = options
 
@@ -58,7 +58,9 @@ const rate = (teams: Team[], options: Options = {}): Team[] => {
     )
   }
 
-  return reorderedTeams
+  // the runtime always returns teams matching the input shape; the cast bridges
+  // the dynamically built Team[] to the statically inferred RateResult<T>.
+  return reorderedTeams as RateResult<T>
 }
 
 export default rate

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,23 +5,12 @@ export type Rating = {
 
 export type Team = Rating[]
 
-// Teams is the input shape accepted by rate(): a list of teams, each team a
-// list of ratings. It is declared with `readonly` so that `const` type
-// parameters can capture the exact tuple lengths of literal arguments.
 export type Teams = readonly (readonly Rating[])[]
 
-// RateTeam replaces every rating in a single team with a freshly computed
-// Rating while preserving the team's length. U is a naked type parameter so the
-// mapped type stays homomorphic and keeps the array/tuple structure intact.
 export type RateTeam<U extends readonly Rating[]> = {
   -readonly [J in keyof U]: Rating
 }
 
-// RateResult mirrors the shape of the input teams: the same number of teams,
-// and within each team the same number of ratings, with every rating replaced
-// by a freshly computed Rating. Homomorphic mapped types preserve tuple lengths
-// when the input was inferred as a tuple (e.g. an array literal captured by a
-// `const` type parameter), while a plain Rating[][] maps back to Rating[][].
 export type RateResult<T extends Teams> = {
   -readonly [K in keyof T]: RateTeam<T[K]>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,27 @@ export type Rating = {
 
 export type Team = Rating[]
 
+// Teams is the input shape accepted by rate(): a list of teams, each team a
+// list of ratings. It is declared with `readonly` so that `const` type
+// parameters can capture the exact tuple lengths of literal arguments.
+export type Teams = readonly (readonly Rating[])[]
+
+// RateTeam replaces every rating in a single team with a freshly computed
+// Rating while preserving the team's length. U is a naked type parameter so the
+// mapped type stays homomorphic and keeps the array/tuple structure intact.
+export type RateTeam<U extends readonly Rating[]> = {
+  -readonly [J in keyof U]: Rating
+}
+
+// RateResult mirrors the shape of the input teams: the same number of teams,
+// and within each team the same number of ratings, with every rating replaced
+// by a freshly computed Rating. Homomorphic mapped types preserve tuple lengths
+// when the input was inferred as a tuple (e.g. an array literal captured by a
+// `const` type parameter), while a plain Rating[][] maps back to Rating[][].
+export type RateResult<T extends Teams> = {
+  -readonly [K in keyof T]: RateTeam<T[K]>
+}
+
 export type Rank = number
 
 export type Gamma = (c: number, k: number, mu: number, sigmaSq: number, team: Rating[], qRank: number) => number

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./src/**/_helpers.ts", "./src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Makes the TypeScript type of `rate()` reflect the shape of its input. If you pass a 2-D array of teams where each team has its own number of ratings, the output type is a tuple of teams with the **same** per-team rating counts.

For example, three teams with 5, 4 and 7 ratings now produce an output typed as a three-team tuple with 5, 4 and 7 ratings respectively:

```ts
const out = rate([
  [a, b, c, d, e],    // 5
  [a, b, c, d],       // 4
  [a, b, c, d, e, f, g], // 7
])
// out: [
//   [Rating, Rating, Rating, Rating, Rating],
//   [Rating, Rating, Rating, Rating],
//   [Rating, Rating, Rating, Rating, Rating, Rating, Rating],
// ]
```

## How it works

- `rate` is now generic over a `const` type parameter `T extends Teams`, so array-literal arguments are captured as tuples (with their exact lengths) rather than widened to `Rating[][]`.
- New homomorphic mapped types `RateTeam` / `RateResult` rebuild the same nested tuple shape with each rating replaced by a freshly computed `Rating`. The inner mapping uses a naked type parameter so the array/tuple structure is preserved (an indexed-access mapping would have collapsed it).
- Indexing past the known length (e.g. a 4th team, or a 6th rating on a 5-rating team) is now a compile error.

## Backwards compatibility

Passing a non-literal `Rating[][]` still type-checks and maps back to `Rating[][]`, so existing call sites are unaffected. Runtime behavior is unchanged — only the static type is more precise.

## Verification

- Added `src/__tests__/rate-types.test-d.ts` with compile-time assertions covering asymmetric teams, options, out-of-bounds indexing, and the `Rating[][]` fallback.
- Added a `typecheck` npm script (`tsconfig.typecheck.json`) and wired it into the `lint` CI job so these type guarantees are enforced.
- `npm run lint`, `npm run typecheck`, `npm run build`, and `npm test` (212 passing) all green.

https://claude.ai/code/session_01WWp3JyWdvb8RAgYeRPBe7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWp3JyWdvb8RAgYeRPBe7J)_