### PR TITLE
ci: add npm staged publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,4 +40,5 @@ jobs:
 
       # Trusted publishing (OIDC) authenticates via the id-token above, so no
       # NODE_AUTH_TOKEN is needed. Provenance is attached automatically.
-      - run: npm publish --access public
+      # Creates a staged publish that must be promoted to go live.
+      - run: npm stage publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+env:
+  CI: true
+
+# Trusted publishing to npm requires an OIDC token, and provenance
+# attestations are written to the public transparency log.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/openskill
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+
+      # npm 11.5.1+ is required for OIDC trusted publishing.
+      - run: npm install -g npm@latest
+
+      - run: npm install
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build
+
+      # Trusted publishing (OIDC) authenticates via the id-token above, so no
+      # NODE_AUTH_TOKEN is needed. Provenance is attached automatically.
+      - run: npm publish --access public


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` to publish `openskill` to npm using a **staged / trusted publish** flow.

- Triggers on GitHub `release: published` (plus manual `workflow_dispatch`).
- Uses npm **OIDC trusted publishing** via `id-token: write` — no long-lived `NODE_AUTH_TOKEN` secret required.
- Publishes with **provenance** attached automatically.
- Gates the publish behind `lint`, `typecheck`, `test`, and `build`.
- Runs in a protected `npm` GitHub Environment so the release step can require review.

## Setup notes

To use trusted publishing, configure this repo + workflow as a trusted publisher on the npm package settings page (Settings → Trusted publishers). Once configured, no npm token needs to be stored in GitHub.

https://claude.ai/code/session_01TehDdUGycrXsTuukEMZ9fo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TehDdUGycrXsTuukEMZ9fo)_