### PR TITLE
chore: bump version to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.0.1
+
+- Shrinks the published package from ~683KB to ~194KB by emitting external
+  sourcemaps and excluding them from the npm tarball, rather than embedding
+  inline base64 sourcemaps in every module. No runtime changes.
+
 ## v5.0.0
 
 - Outputs should now match bit-for-bit with the [python](https://github.com/vivekjoshy/openskill.py)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openskill",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Weng-Lin Bayesian approximation method for online skill-ranking.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Bumps the version to **5.0.1** to re-release `5.0.0` with the slim tarball.

`5.0.0` is already published to npm at the old ~683 KB, and npm versions are immutable — they can't be overwritten. So the packaging fix from #1012 (external sourcemaps excluded from the tarball, ~683 KB → ~194 KB) ships as a patch release. **No runtime/code changes.**

## Changes
- `package.json`: `5.0.0` → `5.0.1`
- `CHANGELOG.md`: add v5.0.1 entry

## Releasing after merge
1. Create a GitHub Release for tag `v5.0.1` → triggers `publish.yml`.
2. Ensure the npm trusted publisher is configured for this repo + workflow.
3. Promote the staged publish to make it live.

https://claude.ai/code/session_01TehDdUGycrXsTuukEMZ9fo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TehDdUGycrXsTuukEMZ9fo)_