### PR TITLE
Update dev dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+## Dependency Versioning
+
+All dependencies in `package.json` must be pinned to exact versions (no caret `^` or tilde `~` prefixes). This is important because:
+
+- Prevents unintended minor/patch version changes
+- Allows Renovate to manage updates deterministically
+- Keeps version control clean with explicit version bumps
+
+When updating dependencies:
+1. Use `npm install package@version` to install a specific version
+2. Remove any `^` or `~` prefixes in package.json
+3. Verify tests pass before committing

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/recommended": "1.0.13",
     "esbuild": "0.28.1",
-    "eslint": "^10.6.0",
+    "eslint": "10.6.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.6",
     "husky": "9.1.7",
@@ -67,7 +67,7 @@
     "tsup": "8.5.1",
     "tsx": "4.22.4",
     "typescript": "6.0.3",
-    "typescript-eslint": "^8.62.0"
+    "typescript-eslint": "8.62.0"
   },
   "prettier": "@philihp/prettier-config",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/recommended": "1.0.13",
     "esbuild": "0.28.1",
-    "eslint": "10.5.0",
+    "eslint": "^10.6.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.6",
     "husky": "9.1.7",
@@ -67,7 +67,7 @@
     "tsup": "8.5.1",
     "tsx": "4.22.4",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.61.1"
+    "typescript-eslint": "^8.62.0"
   },
   "prettier": "@philihp/prettier-config",
   "dependencies": {


### PR DESCRIPTION
## Summary
Updated out-of-date dev dependencies to their latest versions.

## Changes
- eslint: 10.5.0 → 10.6.0
- typescript-eslint: 8.61.1 → 8.62.0

## Test plan
- ✅ Build passes
- ✅ Type checking passes
- ✅ All tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTopQ5H7rWB4Q4ziB3CDFi)_