### PR TITLE
Extract shared per-player update into updatePlayer

### DIFF
--- a/src/models/bradley-terry-full.ts
+++ b/src/models/bradley-terry-full.ts
@@ -1,4 +1,4 @@
-import util, { score } from '../util'
+import util, { score, updatePlayer } from '../util'
 import constants from '../constants'
 import { Rating, Options, Model } from '../types'
 
@@ -26,15 +26,7 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
         { omega: 0, delta: 0 }
       )
 
-    return iTeam.map((player, j) => {
-      const w = weight?.[i]?.[j] ?? 1
-      const sigmaSq = player.sigma * player.sigma
-      const factor = iOmega >= 0 ? w : 1 / w
-      return {
-        mu: player.mu + (sigmaSq / iSigmaSq) * iOmega * factor,
-        sigma: player.sigma * Math.sqrt(Math.max(1 - (sigmaSq / iSigmaSq) * iDelta * factor, KAPPA)),
-      }
-    })
+    return iTeam.map((player, j) => updatePlayer(player, iOmega, iDelta, iSigmaSq, weight?.[i]?.[j] ?? 1, KAPPA))
   })
 }
 

--- a/src/models/bradley-terry-part.ts
+++ b/src/models/bradley-terry-part.ts
@@ -1,5 +1,5 @@
 import { zip } from 'ramda'
-import util, { score, ladderPairs } from '../util'
+import util, { score, ladderPairs, updatePlayer } from '../util'
 import constants from '../constants'
 import { Model, Rating } from '../types'
 
@@ -27,15 +27,7 @@ const model: Model = (game: Rating[][], options = {}) => {
       { omega: 0, delta: 0 }
     )
 
-    return iTeam.map((player, j) => {
-      const w = weight?.[i]?.[j] ?? 1
-      const sigmaSq = player.sigma * player.sigma
-      const factor = iOmega >= 0 ? w : 1 / w
-      return {
-        mu: player.mu + (sigmaSq / iSigmaSq) * iOmega * factor,
-        sigma: player.sigma * Math.sqrt(Math.max(1 - (sigmaSq / iSigmaSq) * iDelta * factor, KAPPA)),
-      }
-    })
+    return iTeam.map((player, j) => updatePlayer(player, iOmega, iDelta, iSigmaSq, weight?.[i]?.[j] ?? 1, KAPPA))
   })
 }
 

--- a/src/models/plackett-luce.ts
+++ b/src/models/plackett-luce.ts
@@ -1,4 +1,4 @@
-import util, { utilSumQ, utilA } from '../util'
+import util, { utilSumQ, utilA, updatePlayer } from '../util'
 import constants from '../constants'
 import { Rating, Options, Model } from '../types'
 
@@ -29,15 +29,7 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
     const iOmega = omegaSum * (iSigmaSq / c)
     const iDelta = deltaSum * (iSigmaSq / c ** 2) * iGamma
 
-    return iTeam.map((player, j) => {
-      const w = weight?.[i]?.[j] ?? 1
-      const sigmaSq = player.sigma * player.sigma
-      const factor = iOmega >= 0 ? w : 1 / w
-      return {
-        mu: player.mu + (sigmaSq / iSigmaSq) * iOmega * factor,
-        sigma: player.sigma * Math.sqrt(Math.max(1 - (sigmaSq / iSigmaSq) * iDelta * factor, KAPPA)),
-      }
-    })
+    return iTeam.map((player, j) => updatePlayer(player, iOmega, iDelta, iSigmaSq, weight?.[i]?.[j] ?? 1, KAPPA))
   })
 }
 

--- a/src/models/thurstone-mosteller-full.ts
+++ b/src/models/thurstone-mosteller-full.ts
@@ -1,4 +1,4 @@
-import util from '../util'
+import util, { updatePlayer } from '../util'
 import constants from '../constants'
 import { w, v, vt, wt } from '../statistics'
 import { Rating, Options, Model } from '../types'
@@ -34,15 +34,7 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
         { omega: 0, delta: 0 }
       )
 
-    return iTeam.map((player, j) => {
-      const w = weight?.[i]?.[j] ?? 1
-      const sigmaSq = player.sigma * player.sigma
-      const factor = iOmega >= 0 ? w : 1 / w
-      return {
-        mu: player.mu + (sigmaSq / iSigmaSq) * iOmega * factor,
-        sigma: player.sigma * Math.sqrt(Math.max(1 - (sigmaSq / iSigmaSq) * iDelta * factor, KAPPA)),
-      }
-    })
+    return iTeam.map((player, j) => updatePlayer(player, iOmega, iDelta, iSigmaSq, weight?.[i]?.[j] ?? 1, KAPPA))
   })
 }
 

--- a/src/models/thurstone-mosteller-part.ts
+++ b/src/models/thurstone-mosteller-part.ts
@@ -1,5 +1,5 @@
 import { zip } from 'ramda'
-import util, { ladderPairs } from '../util'
+import util, { ladderPairs, updatePlayer } from '../util'
 import { w, v, vt, wt } from '../statistics'
 import constants from '../constants'
 import { Rating, Options, Model } from '../types'
@@ -34,15 +34,7 @@ const model: Model = (game: Rating[][], options: Options = {}) => {
       { omega: 0, delta: 0 }
     )
 
-    return iTeam.map((player, j) => {
-      const w = weight?.[i]?.[j] ?? 1
-      const sigmaSq = player.sigma * player.sigma
-      const factor = iOmega >= 0 ? w : 1 / w
-      return {
-        mu: player.mu + (sigmaSq / iSigmaSq) * iOmega * factor,
-        sigma: player.sigma * Math.sqrt(Math.max(1 - (sigmaSq / iSigmaSq) * iDelta * factor, KAPPA)),
-      }
-    })
+    return iTeam.map((player, j) => updatePlayer(player, iOmega, iDelta, iSigmaSq, weight?.[i]?.[j] ?? 1, KAPPA))
   })
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,6 +38,30 @@ export const normalize = (vector: number[], targetMin: number, targetMax: number
   return vector.map((value) => ((value - sourceMin) / sourceRange) * targetRange + targetMin)
 }
 
+/**
+ * Apply a model's team-level `omega`/`delta` to a single player, scaled by a
+ * partial-play `weight`. The weight amplifies the update when the team's omega
+ * is non-negative and damps it when negative (matching openskill.py's
+ * asymmetric handling); a weight of `1` is a no-op. Shared by every Weng-Lin
+ * model — they differ in how omega and delta are derived, not in how those map
+ * back onto each player.
+ */
+export const updatePlayer = (
+  { mu, sigma }: Rating,
+  iOmega: number,
+  iDelta: number,
+  iSigmaSq: number,
+  weight: number,
+  kappa: number
+): Rating => {
+  const sigmaSq = sigma * sigma
+  const w = iOmega >= 0 ? weight : 1 / weight
+  return {
+    mu: mu + (sigmaSq / iSigmaSq) * iOmega * w,
+    sigma: sigma * Math.sqrt(Math.max(1 - (sigmaSq / iSigmaSq) * iDelta * w, kappa)),
+  }
+}
+
 export const rankings = (teams: Team[], rank: number[] = []) => {
   const teamScores = teams.map((_, i) => rank[i] ?? i)
   const outRank = new Array(teams.length)


### PR DESCRIPTION
## What

All five Weng-Lin models (`plackettLuce`, `bradleyTerryFull`, `bradleyTerryPart`, `thurstoneMostellerFull`, `thurstoneMostellerPart`) end with the same per-player step: map the team-level `omega`/`delta` — scaled by the partial-play `weight` — onto each player's `mu`/`sigma`. Only the *derivation* of `omega`/`delta` differs between models. This pulls that shared tail into a single `updatePlayer` helper in `util.ts`:

```ts
return iTeam.map((player, j) => updatePlayer(player, iOmega, iDelta, iSigmaSq, weight?.[i]?.[j] ?? 1, KAPPA))
```

## Why

It was duplicated five times. One copy is easier to read and to change.

## Notes

- **Pure refactor — no behavior change.** The full suite passes (271 tests, 13 documented parity skips); typecheck and lint are clean.
- Rebased onto `main` after #1024 (partial-play weights) merged, so the extracted helper carries the per-player `weight` and the asymmetric `omega >= 0 ? weight : 1 / weight` scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WL5w21pDHbhu9PoajTndNp