### PR TITLE
docs: advertise current feature set

### DIFF
--- a/docs/app/api/page.mdx
+++ b/docs/app/api/page.mdx
@@ -41,8 +41,13 @@ rate(
       | typeof thurstoneMostellerPart
     rank?: number[]
     score?: number[]
+    margin?: number
+    weight?: number[][]
+    weightBounds?: [number, number] | null
     tau?: number
-    preventSigmaIncrease?: boolean
+    limitSigma?: boolean
+    balance?: boolean
+    gamma?: Gamma
     mu?: number
     sigma?: number
     beta?: number
@@ -79,6 +84,79 @@ rate([[a1], [b1], [c1], [d1]], { score: [37, 19, 37, 42] })
 // → 🥈 🐌 🥈 🥇
 ```
 
+### With victory margins
+
+When both `score` and `margin` are given, rating updates are amplified for
+wins by more than `margin` points. A 20-point blowout moves ratings more
+than a 1-point squeaker; the amplification grows logarithmically, so extreme
+blowouts don't produce runaway swings. Score gaps within the margin update
+as ordinary wins/losses.
+
+```js
+rate(
+  [
+    [a1, a2],
+    [b1, b2],
+  ],
+  { score: [37, 12], margin: 10 }
+)
+```
+
+### With partial-play weights
+
+`weight` scales each player's rating update by their contribution to the
+match — useful when a player only played part of a game, or you have a
+per-player contribution metric (damage dealt, objectives captured, minutes
+played). It's shaped like `teams`: one number per player.
+
+```js
+rate(
+  [
+    [a1, a2],
+    [b1, b2],
+  ],
+  {
+    weight: [
+      [1, 0.5], // a2 only played half the game
+      [1, 1],
+    ],
+  }
+)
+```
+
+By default each team's weights are normalized into `[1, 2]`, so only the
+*relative* differences within a team matter — matching
+[openskill.py](https://github.com/vivekjoshy/openskill.py) bit-for-bit.
+Change the range with `weightBounds: [min, max]`, or pass
+`weightBounds: null` to apply your raw weights as-is.
+
+### With `tau` and `limitSigma`
+
+`tau` (default `25/300`) is an additive dynamics factor that keeps `sigma`
+from collapsing to zero over many games, so ratings stay responsive to skill
+changes. A side effect is that `sigma` can *increase*, which can make a
+player's [ordinal](#ordinalrating-options) drop even after a win. Set
+`limitSigma: true` to clamp `sigma` so it never rises.
+
+```js
+rate(teams, { tau: 0.3, limitSigma: true })
+```
+
+### With `balance`
+
+`balance: true` weights weaker players' contributions to their team's rating
+more heavily, emphasizing skill disparity within a team.
+
+```js
+rate(teams, { balance: true })
+```
+
+### Custom `gamma`
+
+Advanced: pass a `gamma` function to override how much each team's `sigma`
+shrinks per update. The default is `sigma / c` (where `c` is the total
+uncertainty in the match).
+
 ## `ordinal(rating, options?)`
 
 Reduce a rating to a single number for display or sorting.
@@ -91,32 +169,45 @@ ordinal(r: Rating, options?: { z?: number; alpha?: number; target?: number }): n
 ordinal({ mu: 25, sigma: 8.333 }) // ≈ 0.0
 ```
 
-## `predictWin(teams)`
+## `predictWin(teams, options?)`
 
 Returns an array of probabilities, one per team, that sums to 1.
 
 ```js
+const a1 = rating()
+const b1 = rating({ mu: 33.564, sigma: 1.123 })
+
 predictWin([[a1], [b1]])
-// [0.4511..., 0.5489...]
+// [0.2021..., 0.7978...]
 ```
 
-## `predictDraw(teams)`
+## `predictDraw(teams, options?)`
 
 Returns the relative likelihood that a match between these teams ends in a
 draw. Useful for matchmaking quality scores.
 
 ```js
 predictDraw([[a1], [b1]])
-// 0.0902...
+// 0.2164...
 ```
 
-## `predictRank(teams)`
+## `predictRank(teams, options?)`
 
-Returns the predicted finishing order with associated probabilities.
+Returns, for each team, its predicted placement and the probability of that
+placement.
 
 ```js
+const a1 = rating()
+const b1 = rating({ mu: 30, sigma: 5 })
+const c1 = rating({ mu: 20, sigma: 8 })
+
 predictRank([[a1], [b1], [c1]])
+// [[2, 0.3276...], [1, 0.4867...], [3, 0.1855...]]
 ```
+
+All three predictors accept the same hyperparameter options as `rate`
+(`mu`, `sigma`, `beta`, `balance`, …) so predictions stay consistent with
+however you rate.
 
 ## Selecting a model
 

--- a/docs/app/getting-started/page.mdx
+++ b/docs/app/getting-started/page.mdx
@@ -84,8 +84,25 @@ bit-for-bit. To get there, a few defaults changed:
   `erf` using Python's `NormalDist` formulas. This only affects the
   Thurstone-Mosteller models.
 
+## Beyond the basics
+
+`rate` also supports:
+
+- **Ranks and scores** — `rank: [4, 1, 3, 2]` or `score: [37, 19, 37, 42]`
+  for arbitrary orderings and ties ([Ranking →](/ranking))
+- **Victory margins** — `margin` amplifies updates for lopsided scores
+  ([Ranking →](/ranking))
+- **Partial play** — `weight` scales each player's update by their
+  contribution ([Ranking →](/ranking))
+- **Alternate models** — Bradley-Terry and Thurstone-Mosteller variants
+  ([Models →](/models))
+- **Tuning** — `tau`, `limitSigma`, `balance`, and the underlying
+  hyperparameters ([API Reference →](/api))
+
 ## Next
 
 - [API Reference →](/api)
+- [Ranking & Ordinal →](/ranking)
 - [Models →](/models)
+- [Predictions →](/predictions)
 - [Examples by language →](/examples/javascript)

--- a/docs/app/page.mdx
+++ b/docs/app/page.mdx
@@ -11,12 +11,15 @@ skill-ranking method, described in
 [*A Bayesian Approximation Method for Online Ranking*](https://www.csie.ntu.edu.tw/~cjlin/papers/online_ranking/online_journal.pdf).
 
 `openskill` is a faster, simpler, and patent-free alternative to TrueSkill that
-supports asymmetric teams, free-for-all matches, partial rankings, and ties.
+supports asymmetric teams, free-for-all matches, partial rankings, ties,
+partial play, and victory margins.
 
 ## Why openskill?
 
 - **Fast** — up to 20× faster than TrueSkill (see the [benchmarks](#speed)).
-- **Flexible** — Bradley-Terry, Thurstone-Mosteller, and Plackett-Luce models.
+- **Flexible** — Bradley-Terry, Thurstone-Mosteller, and Plackett-Luce models,
+  plus per-player [partial-play weights](/ranking) and score-based
+  [victory margins](/ranking).
 - **Portable** — bit-for-bit compatible with the reference
   [Python implementation](https://github.com/vivekjoshy/openskill.py), so you
   can train in one runtime and serve in another.

--- a/docs/app/predictions/page.mdx
+++ b/docs/app/predictions/page.mdx
@@ -1,7 +1,9 @@
 # Predictions
 
 `openskill` exposes three prediction helpers in addition to `rate`. They take
-the same `teams` shape as `rate` and never mutate the inputs.
+the same `teams` shape as `rate` and never mutate the inputs. Each also
+accepts the same hyperparameter options as `rate` (`mu`, `sigma`, `beta`,
+`balance`, …), so predictions stay consistent with however you rate.
 
 ## `predictWin`
 
@@ -14,7 +16,7 @@ const a1 = rating()
 const a2 = rating({ mu: 33.564, sigma: 1.123 })
 
 const probs = predictWin([[a1], [a2]])
-// [ 0.4511..., 0.5489... ]
+// [ 0.2021..., 0.7978... ]
 
 probs[0] + probs[1] // 1
 ```
@@ -29,7 +31,7 @@ absolute value depends on the rules of your game.
 import { predictDraw } from 'openskill'
 
 predictDraw([[a1], [a2]])
-// 0.0902...
+// 0.2164...
 ```
 
 This is analogous to the *quality* metric in TrueSkill — use it to optimize
@@ -37,11 +39,17 @@ matchmaking, seedings, or tournament brackets.
 
 ## `predictRank`
 
-The predicted finishing order with associated probabilities. Useful when you
-care about more than just *who wins*.
+The predicted finishing order with associated probabilities — one
+`[placement, probability]` pair per team. Useful when you care about more
+than just *who wins*.
 
 ```js
-import { predictRank } from 'openskill'
+import { rating, predictRank } from 'openskill'
+
+const a1 = rating()
+const b1 = rating({ mu: 30, sigma: 5 })
+const c1 = rating({ mu: 20, sigma: 8 })
 
 predictRank([[a1], [b1], [c1]])
+// [[2, 0.3276...], [1, 0.4867...], [3, 0.1855...]]
 ```

--- a/docs/app/ranking/page.mdx
+++ b/docs/app/ranking/page.mdx
@@ -44,6 +44,45 @@ const [[a2], [b2], [c2], [d2]] = rate(
 )
 ```
 
+## Victory margins with `margin`
+
+When you pass `score`, you can also pass `margin` to make the *size* of a
+victory matter. Score gaps larger than `margin` amplify the rating update —
+logarithmically, so blowouts don't cause runaway swings — while gaps within
+the margin count as ordinary wins/losses.
+
+```js
+const [[a2], [b2]] = rate(
+  [[a1], [b1]],
+  { score: [37, 12], margin: 10 } // a 25-point win, amplified
+)
+```
+
+## Partial play with `weight`
+
+If a player only participated for part of a match — or you track a
+contribution metric like time played or objectives captured — pass `weight`,
+shaped like `teams`, to scale each player's update.
+
+```js
+const [[a2, b2], [c2, d2]] = rate(
+  [
+    [a1, b1],
+    [c1, d1],
+  ],
+  {
+    weight: [
+      [1, 0.5], // b1 only played half the match
+      [1, 1],
+    ],
+  }
+)
+```
+
+Weights are normalized per team into `[1, 2]` by default (only relative
+differences within a team matter). See the [API reference](/api) for
+`weightBounds`.
+
 ## Ties
 
 Ties are encoded as equal `rank` or equal `score`. Players sharing a position


### PR DESCRIPTION
Updates the docs site to cover the library's current feature set.

## Changes

- **API reference** (`/api`)
  - Documents the `margin` option (score-based victory-margin amplification via `marginFactor`), `weight`/`weightBounds` partial-play options, `limitSigma`, `balance`, and custom `gamma` on `rate()`, with examples for each.
  - Fixes the stale option name `preventSigmaIncrease` → the actual `limitSigma`.
  - Shows that `predictWin`/`predictDraw`/`predictRank` accept the same hyperparameter options as `rate()`, and shows `predictRank`'s `[placement, probability]` output shape.
- **Ranking** (`/ranking`) — adds "Victory margins with `margin`" and "Partial play with `weight`" sections.
- **Predictions** (`/predictions`) — refreshes example outputs to match what the current library actually returns (verified by running the examples against `src/`); the old numbers were stale.
- **Getting Started** — adds a "Beyond the basics" overview linking each feature to its docs page.
- **Landing page** — mentions partial play and victory margins.

All example inputs/outputs were verified against the current source with `tsx`.

## Notes

The docs site build (`docs/ && npm run build`) currently fails on `main` with a Next.js 16.3 / `@next/mdx` loader-serialization error (`does not have serializable options`); this is pre-existing and unrelated to these content-only MDX changes — verified by building a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkVUqWPKbt9heAAdH7gyXv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkVUqWPKbt9heAAdH7gyXv)_