### PR TITLE
fix: hide sourcemap references in published files

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
   entry: ['src/index.ts', 'src/models/index.ts'],
   format: ['cjs', 'esm'],
-  sourcemap: true,
+  sourcemap: 'hidden',
   clean: true,
   dts: true,
   hash: false,


### PR DESCRIPTION
## Summary

- Generate hidden sourcemaps with tsdown
- Keep sourcemaps available in local build output
- Stop emitting dangling `sourceMappingURL` annotations

## Context

PR #1012 reduced the published package size by externalizing sourcemaps and excluding `.map` files from the npm package. However, generated JavaScript and declaration files still contained `sourceMappingURL` annotations pointing to those excluded files.

This caused consumers such as Vite to report missing sourcemap warnings.

## Why

Using hidden sourcemaps preserves local debugging support while preventing consumers from requesting files that are not included in the npm package.

## Testing

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
- Verified that built files contain no `sourceMappingURL` annotations
- Verified that the npm package contains neither sourcemap files nor dangling sourcemap references